### PR TITLE
chore(deps): bump proto toolchain to latest patch/minor versions

### DIFF
--- a/.prototools
+++ b/.prototools
@@ -1,7 +1,7 @@
-moon = "2.4.5"
-node = "24.18.0"
-yarn = "4.17.1"
-npm = "11.18.0"
+moon = "2.4.6"
+node = "24.18.1"
+yarn = "4.18.0"
+npm = "11.19.0"
 
 [settings]
 auto-install = true


### PR DESCRIPTION
## Summary

Scheduled dependency scan of every `.prototools` entry and `package.json` (58 manifests, npm/yarn ecosystem only — composer/PHP out of scope per instructions). This PR applies the toolchain bumps that are safe to make without a working `yarn` in this session's sandbox (see **Why this PR is small** below).

## `.prototools` toolchain — updated

| Tool | From | To | Type | Notes |
|---|---|---|---|---|
| moon | 2.4.5 | 2.4.6 | patch | Fixes `MOON_BASE`/`MOON_HEAD` requiring `--affected`, and a GitLab CI merge-request HEAD bug. No breaking changes. |
| node | 24.18.0 | 24.18.1 | patch | Latest 24.x LTS ("Krypton") point release. |
| yarn | 4.17.1 | 4.18.0 | minor | Prefers direct-dependency binaries, hoisting-limit fix. No breaking changes documented. |
| npm | 11.18.0 | 11.19.0 | minor | Last release on the npm 11 line (npm 12 shipped the same day as a major with breaking changes — see below, intentionally not applied here). |

## Why this PR is small: an equivalent PR already covers the npm dependency bumps

**#206 (`chore(deps): bump outdated npm dependencies (patch/minor)`) is already open and draft**, from last week's run of this same scheduled scan. It already applied every available patch/minor bump across `package.json`/`yarn.lock` (prettier, eslint, eslint-plugin-vue, globals, typescript-eslint, Storybook, unhead, vite-plugin-vue-devtools, tanstack-vue-query, vue-i18n, Playwright, the 24 `@tiptap/*` packages, etc.) and correctly excluded the one major bump available (TypeScript, see below).

That PR is currently **blocked**, not by its own changes, but by a **pre-existing issue it surfaced**: regenerating `yarn.lock` for real (this session's sandbox cannot reach `repo.yarnpkg.com` to do the same — egress policy denies it, confirmed via 403) exposed that `main`'s checked-in `yarn.lock` has been drifting from `package.json` for months, because several prior automated-bump sessions could not reach the registry either and skipped the lockfile refresh. A genuine `yarn install` against current `main` surfaces ~215 latent `vue-tsc` type errors (stale OpenAPI SDK types, moon build-graph ordering) that CI has never actually exercised. That's a real, separate body of work, flagged in detail in [PR #206's comment](https://github.com/lychen-lab/lychen/pull/206#issuecomment-5085987567) — **recommend triaging that before merging either PR.**

Since I could not reach the yarn registry from this sandbox, I did not attempt to touch `package.json`/`yarn.lock` again here to avoid producing a second, conflicting resolution of the same lockfile. This PR is scoped to `.prototools` only, which needed no registry access to edit safely.

### New patch/minor versions published since #206 (2026-07-26) — for the eventual lockfile refresh
`globals` 17.8.0→17.9.0, `storybook`/`@storybook/*` 10.5.4→10.5.5, `@tiptap/*` 3.29.0→3.29.2, `@playwright/test` 1.62.0→1.62.1, `vue-tsc` 3.3.8→3.3.9, plus several packages not yet touched by #206 at all: `vue` 3.5.38→3.5.40, `vue-router` 5.1.0→5.2.0, `tailwindcss`/`@tailwindcss/vite` 4.3.0→4.3.3, `vitest` 4.1.8→4.1.10, `reka-ui` 2.9.10→2.10.1, `eslint-plugin-yml` 3.4.0→3.7.0, `eslint-plugin-check-file` 3.3.1→3.3.2, `vue-eslint-parser` 10.4.0→10.4.1, `@eslint/markdown` 8.0.2→8.0.3, `@internationalized/date`, `@intlify/core-base`, `@vitejs/plugin-vue`, `@faker-js/faker`. Whoever refreshes the lockfile next should pick these up too.

## Excluded majors (flagged, not applied)

- **TypeScript 6.0.3 → 7.0.2.** TS 7 is the Go-native rewrite and ships **without a public compiler API**. This repo's `vue-tsc` and `typescript-eslint` both depend on that API and are not yet compatible — upgrading now breaks type-checking and linting repo-wide. Re-evaluate once the Vue/TS tooling ecosystem ships TS-7-compatible releases. ([details](https://www.digitalapplied.com/blog/typescript-7-0-rc-go-native-compiler-2026-upgrade-guide))
- **npm 11.19.0 → 12.0.2.** npm 12 disables `postinstall` scripts, git dependencies, and remote-tarball installs by default (security-motivated), and makes unknown/abbreviated CLI flags hard-error instead of warn. Compatible with our pinned Node (`^24.15.0` satisfied), but it's a genuine behavior change for anything relying on install scripts or loose flag parsing — worth a deliberate opt-in rather than an automatic bump. ([details](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/))

## Security

- Checked every currently-resolved npm/yarn package version (92 unique deps across all 58 manifests) against the npm bulk security-advisories endpoint (`registry.npmjs.org/-/npm/v1/security/advisories/bulk`) — **no advisories or CVEs found** for any of them at their current versions.
- **GitHub reports 104 Dependabot alerts on `main`** as of this push (1 critical, 50 high, 47 moderate, 6 low) — up from 96 (1 critical, 44 high, 45 moderate, 6 low) a week ago at PR #206. This session doesn't have access to the Dependabot Alerts API to attribute these to specific packages/ecosystems. **Given the critical/high count and the upward trend, this is worth a direct look at Security → Dependabot** rather than waiting on the next scheduled scan.

## Test plan

- [x] `.prototools` versions verified against moonrepo/moon, nodejs.org, and the `@yarnpkg/cli`/`npm` npm registry entries
- [ ] `proto install` picks up the new pins (not run in this sandbox — proto's toolchain downloads go through the same restricted egress as yarn)
- [ ] CI

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8vDM3RqWwLj4CPXShSe3N)_