### PR TITLE
fix(espace-api): make the API bootable from a fresh checkout

### DIFF
--- a/projects/espace/api/compose.override.yml
+++ b/projects/espace/api/compose.override.yml
@@ -1,4 +1,9 @@
 # Development environment override
+# Pin the compose project name: every API lives in a directory called `api`, so
+# without this a bare `docker compose` (or `make up`) derives the project name
+# from that directory and all APIs collide on the same containers and volumes.
+# Moon tasks pass `-p $project`, which resolves to this same value.
+name: espace-api
 services:
     database:
         ports:

--- a/projects/espace/api/public/index.php
+++ b/projects/espace/api/public/index.php
@@ -1,0 +1,10 @@
+<?php
+umask(0002);
+
+use App\Kernel;
+
+require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
+
+return function (array $context) {
+    return new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);
+};

--- a/projects/flora/api/compose.override.yml
+++ b/projects/flora/api/compose.override.yml
@@ -1,4 +1,9 @@
 # Development environment override
+# Pin the compose project name: every API lives in a directory called `api`, so
+# without this a bare `docker compose` (or `make up`) derives the project name
+# from that directory and all APIs collide on the same containers and volumes.
+# Moon tasks pass `-p $project`, which resolves to this same value.
+name: flora-api
 services:
   database:
     ports:

--- a/projects/tera/api/compose.override.yml
+++ b/projects/tera/api/compose.override.yml
@@ -1,4 +1,9 @@
 # Development environment override
+# Pin the compose project name: every API lives in a directory called `api`, so
+# without this a bare `docker compose` (or `make up`) derives the project name
+# from that directory and all APIs collide on the same containers and volumes.
+# Moon tasks pass `-p $project`, which resolves to this same value.
+name: tera-api
 services:
   database:
     ports:


### PR DESCRIPTION
Two independent bugs both prevented espace-api from starting locally. One commit each.

---

## 1. `fix(compose)` — pin the dev compose project name per API

Every API lives in a directory literally called `api`. Without a `name:`, a bare `docker compose` (or `make up`) derives the compose project name from that basename, so **all three APIs collapse onto the same project `api`** and share containers, volumes and host ports.

#162 (`c9379b4d`, *unify API compose stack across all environments*) removed `name:` from the three `compose.yml`. The regression surfaced as:

```
FATAL:  password authentication failed for user "userlocal"
DETAIL:  Role "userlocal" does not exist.
```

Project `api` had latched onto a stale `api_database_data` volume (created 2025-08-27) that an older stack had `initdb`'d with a different `POSTGRES_USER`. **Postgres only runs `initdb` on an empty data dir**, so `POSTGRES_USER=userlocal` was silently ignored and the superuser stayed `app`.

Two things masked it:

- the stack still reported **healthy** — the healthcheck is `pg_isready`, which does not authenticate;
- `moon <proj>-api:up` kept working, because those tasks already pass `-p $project`. Only the bare-`docker compose` / `make up` path was broken.

**Why `compose.override.yml` and not `compose.yml`:** the override is the dev-only layer, so Dokploy — which reads `compose.yml` and namespaces projects itself — is untouched, and #162's "one compose.yml for every environment" intent is preserved. Moon tasks pass `-p $project`, which resolves to the same value (and CLI `-p` wins over `name:` regardless), so both entry points now land on the same project.

Fixing only espace would have left tera and flora colliding **with each other** on project `api`, hence all three.

## 2. `fix(espace-api)` — commit the missing `public/index.php`

The root `.gitignore` ignores `projects/**/public/*`, allowing back only `static/` and `robots.txt`. That rule targets frontend build output, but it also swallows the Symfony front controller of the API projects.

tera-api and flora-api have `public/index.php` committed anyway; **espace-api never did** — only `robots.txt` is tracked. So espace-api booted only by accident, on checkouts where the file survived as an untracked leftover. From a fresh clone or a git worktree the container dies at startup:

```
Failed opening required '/app/public/index.php'
```

The committed file is byte-identical to tera's and flora's.

## Verification

Ran the full stack from a **fresh worktree** (no untracked leftovers), which is what exposed bug 2:

- `docker compose config` resolves to `espace-api` / `tera-api` / `flora-api`;
- all four containers healthy; Doctrine connects as `userlocal` to `app` on PostgreSQL 16.10;
- the API Platform entrypoint answers `302` → JSON-LD context over HTTPS.

No data was lost: the three candidate Postgres volumes were inspected first and all held zero rows.

## Notes for the reviewer

- `.gitignore:73` (`projects/**/public/*`) is the underlying trap for bug 2. This PR force-adds the one missing file rather than reworking the ignore rule, which would affect every frontend project. Worth a follow-up.
- espace-api is also still missing `public/favicon.ico`, which tera and flora both track. Cosmetic only (404 in dev), left out deliberately to keep this PR to the boot path.
- Cleanup left for later: ~22 orphaned volumes from the collision era (`api_*`, `espace-api_espace_*`, `alfred-api_*`, `api_titan_*`), all unused and empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
