### PR TITLE
feat(espace-api): link AreaProposal to its proposer

### DIFF
--- a/projects/espace/api/composer.lock
+++ b/projects/espace/api/composer.lock
@@ -1617,16 +1617,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.11.0",
+            "version": "2.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
+                "reference": "95e7828100de18b4e269fb1703be530082d5166d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
-                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/95e7828100de18b4e269fb1703be530082d5166d",
+                "reference": "95e7828100de18b4e269fb1703be530082d5166d",
                 "shasum": ""
             },
             "require": {
@@ -1635,7 +1635,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1716,7 +1716,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.1"
             },
             "funding": [
                 {
@@ -1732,7 +1732,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-02T12:30:48+00:00"
+            "time": "2026-08-24T09:13:11+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -4189,16 +4189,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -4236,7 +4236,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -4256,7 +4256,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/doctrine-bridge",

--- a/projects/espace/api/config/reference.php
+++ b/projects/espace/api/config/reference.php
@@ -33,7 +33,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     type?: string|null,
  *     ignore_errors?: bool,
  * }>
- * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|null>|null>
+ * @psalm-type ParametersConfig = array<string, scalar|\UnitEnum|array<scalar|\UnitEnum|array<mixed>|Param|null>|Param|null>
  * @psalm-type ArgumentsType = list<mixed>|array<string, mixed>
  * @psalm-type CallType = array<string, ArgumentsType>|array{0:string, 1?:ArgumentsType, 2?:bool}|array{method:string, arguments?:ArgumentsType, returns_clone?:bool}
  * @psalm-type TagsType = list<string|array<string, array<string, mixed>>> // arrays inside the list must have only one element, with the tag name as the key
@@ -78,6 +78,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     tags?: TagsType,
  *     resource_tags?: TagsType,
  *     decorates?: string,
+ *     decorates_tag?: string,
  *     decoration_inner_name?: string,
  *     decoration_priority?: int,
  *     decoration_on_invalid?: 'exception'|'ignore'|null,
@@ -118,6 +119,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     stack: list<DefinitionType|AliasType|PrototypeType|array<class-string, ArgumentsType|null>>,
  *     public?: bool,
  *     deprecated?: DeprecationType,
+ *     decorates?: string,
+ *     decorates_tag?: string,
+ *     decoration_inner_name?: string,
+ *     decoration_priority?: int,
+ *     decoration_on_invalid?: 'exception'|'ignore'|null,
  * }
  * @psalm-type ServicesConfig = array{
  *     _defaults?: DefaultsType,
@@ -126,49 +132,49 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type ExtensionType = array<string, mixed>
  * @psalm-type FrameworkConfig = array{
- *     secret?: scalar|null|Param,
+ *     secret?: scalar|Param|null,
  *     http_method_override?: bool|Param, // Set true to enable support for the '_method' request parameter to determine the intended HTTP method on POST requests. // Default: false
- *     allowed_http_method_override?: list<string|Param>|null,
- *     trust_x_sendfile_type_header?: scalar|null|Param, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
- *     ide?: scalar|null|Param, // Default: "%env(default::SYMFONY_IDE)%"
+ *     allowed_http_method_override?: null|list<string|Param>,
+ *     trust_x_sendfile_type_header?: scalar|Param|null, // Set true to enable support for xsendfile in binary file responses. // Default: "%env(bool:default::SYMFONY_TRUST_X_SENDFILE_TYPE_HEADER)%"
+ *     ide?: scalar|Param|null, // Default: "%env(default::SYMFONY_IDE)%"
  *     test?: bool|Param,
- *     default_locale?: scalar|null|Param, // Default: "en"
+ *     default_locale?: scalar|Param|null, // Default: "en"
  *     set_locale_from_accept_language?: bool|Param, // Whether to use the Accept-Language HTTP header to set the Request locale (only when the "_locale" request attribute is not passed). // Default: false
  *     set_content_language_from_locale?: bool|Param, // Whether to set the Content-Language HTTP header on the Response using the Request locale. // Default: false
- *     enabled_locales?: list<scalar|null|Param>,
- *     trusted_hosts?: list<scalar|null|Param>,
+ *     enabled_locales?: list<scalar|Param|null>,
+ *     trusted_hosts?: string|list<scalar|Param|null>,
  *     trusted_proxies?: mixed, // Default: ["%env(default::SYMFONY_TRUSTED_PROXIES)%"]
- *     trusted_headers?: list<scalar|null|Param>,
- *     error_controller?: scalar|null|Param, // Default: "error_controller"
+ *     trusted_headers?: string|list<scalar|Param|null>,
+ *     error_controller?: scalar|Param|null, // Default: "error_controller"
  *     handle_all_throwables?: bool|Param, // HttpKernel will handle all kinds of \Throwable. // Default: true
  *     csrf_protection?: bool|array{
- *         enabled?: scalar|null|Param, // Default: null
- *         stateless_token_ids?: list<scalar|null|Param>,
- *         check_header?: scalar|null|Param, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
- *         cookie_name?: scalar|null|Param, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
+ *         enabled?: scalar|Param|null, // Default: null
+ *         stateless_token_ids?: list<scalar|Param|null>,
+ *         check_header?: scalar|Param|null, // Whether to check the CSRF token in a header in addition to a cookie when using stateless protection. // Default: false
+ *         cookie_name?: scalar|Param|null, // The name of the cookie to use when using stateless protection. // Default: "csrf-token"
  *     },
  *     form?: bool|array{ // Form configuration
  *         enabled?: bool|Param, // Default: true
- *         csrf_protection?: array{
- *             enabled?: scalar|null|Param, // Default: null
- *             token_id?: scalar|null|Param, // Default: null
- *             field_name?: scalar|null|Param, // Default: "_token"
- *             field_attr?: array<string, scalar|null|Param>,
+ *         csrf_protection?: bool|array{
+ *             enabled?: scalar|Param|null, // Default: null
+ *             token_id?: scalar|Param|null, // Default: null
+ *             field_name?: scalar|Param|null, // Default: "_token"
+ *             field_attr?: array<string, scalar|Param|null>,
  *         },
  *     },
  *     http_cache?: bool|array{ // HTTP cache configuration
  *         enabled?: bool|Param, // Default: false
  *         debug?: bool|Param, // Default: "%kernel.debug%"
  *         trace_level?: "none"|"short"|"full"|Param,
- *         trace_header?: scalar|null|Param,
+ *         trace_header?: scalar|Param|null,
  *         default_ttl?: int|Param,
- *         private_headers?: list<scalar|null|Param>,
- *         skip_response_headers?: list<scalar|null|Param>,
+ *         private_headers?: list<scalar|Param|null>,
+ *         skip_response_headers?: list<scalar|Param|null>,
  *         allow_reload?: bool|Param,
  *         allow_revalidate?: bool|Param,
  *         stale_while_revalidate?: int|Param,
  *         stale_if_error?: int|Param,
- *         terminate_on_cache_hit?: bool|Param,
+ *         terminate_on_cache_hit?: bool|Param, // Deprecated: Setting the "framework.http_cache.terminate_on_cache_hit.terminate_on_cache_hit" configuration option is deprecated. It will be removed in version 9.0.
  *     },
  *     esi?: bool|array{ // ESI configuration
  *         enabled?: bool|Param, // Default: false
@@ -178,17 +184,17 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     fragments?: bool|array{ // Fragments configuration
  *         enabled?: bool|Param, // Default: false
- *         hinclude_default_template?: scalar|null|Param, // Default: null
- *         path?: scalar|null|Param, // Default: "/_fragment"
+ *         hinclude_default_template?: scalar|Param|null, // Default: null
+ *         path?: scalar|Param|null, // Default: "/_fragment"
  *     },
  *     profiler?: bool|array{ // Profiler configuration
  *         enabled?: bool|Param, // Default: false
  *         collect?: bool|Param, // Default: true
- *         collect_parameter?: scalar|null|Param, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
+ *         collect_parameter?: scalar|Param|null, // The name of the parameter to use to enable or disable collection on a per request basis. // Default: null
  *         only_exceptions?: bool|Param, // Default: false
  *         only_main_requests?: bool|Param, // Default: false
- *         dsn?: scalar|null|Param, // Default: "file:%kernel.cache_dir%/profiler"
- *         collect_serializer_data?: bool|Param, // Enables the serializer data collector and profiler panel. // Default: false
+ *         dsn?: scalar|Param|null, // Default: "file:%kernel.cache_dir%/profiler"
+ *         collect_serializer_data?: true|Param, // Deprecated: Setting the "framework.profiler.collect_serializer_data.collect_serializer_data" configuration option is deprecated. It will be removed in version 9.0. // Default: true
  *     },
  *     workflows?: bool|array{
  *         enabled?: bool|Param, // Default: false
@@ -199,171 +205,165 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             type?: "workflow"|"state_machine"|Param, // Default: "state_machine"
  *             marking_store?: array{
  *                 type?: "method"|Param,
- *                 property?: scalar|null|Param,
- *                 service?: scalar|null|Param,
+ *                 property?: scalar|Param|null,
+ *                 service?: scalar|Param|null,
  *             },
- *             supports?: list<scalar|null|Param>,
- *             definition_validators?: list<scalar|null|Param>,
- *             support_strategy?: scalar|null|Param,
- *             initial_marking?: list<scalar|null|Param>,
- *             events_to_dispatch?: list<string|Param>|null,
- *             places?: list<array{ // Default: []
- *                 name: scalar|null|Param,
- *                 metadata?: list<mixed>,
+ *             supports?: string|list<scalar|Param|null>,
+ *             definition_validators?: list<scalar|Param|null>,
+ *             support_strategy?: scalar|Param|null,
+ *             initial_marking?: \BackedEnum|string|list<scalar|Param|null>,
+ *             events_to_dispatch?: null|list<string|Param>,
+ *             places?: string|list<array{ // Default: []
+ *                 name?: scalar|Param|null,
+ *                 metadata?: array<string, mixed>,
  *             }>,
- *             transitions: list<array{ // Default: []
- *                 name: string|Param,
+ *             transitions?: list<array{ // Default: []
+ *                 name?: string|Param,
  *                 guard?: string|Param, // An expression to block the transition.
- *                 from?: list<array{ // Default: []
- *                     place: string|Param,
+ *                 from?: \BackedEnum|string|list<array{ // Default: []
+ *                     place?: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
- *                 to?: list<array{ // Default: []
- *                     place: string|Param,
+ *                 to?: \BackedEnum|string|list<array{ // Default: []
+ *                     place?: string|Param,
  *                     weight?: int|Param, // Default: 1
  *                 }>,
  *                 weight?: int|Param, // Default: 1
- *                 metadata?: list<mixed>,
+ *                 metadata?: array<string, mixed>,
  *             }>,
- *             metadata?: list<mixed>,
+ *             metadata?: array<string, mixed>,
  *         }>,
  *     },
  *     router?: bool|array{ // Router configuration
  *         enabled?: bool|Param, // Default: false
- *         resource: scalar|null|Param,
- *         type?: scalar|null|Param,
- *         cache_dir?: scalar|null|Param, // Deprecated: Setting the "framework.router.cache_dir.cache_dir" configuration option is deprecated. It will be removed in version 8.0. // Default: "%kernel.build_dir%"
- *         default_uri?: scalar|null|Param, // The default URI used to generate URLs in a non-HTTP context. // Default: null
- *         http_port?: scalar|null|Param, // Default: 80
- *         https_port?: scalar|null|Param, // Default: 443
- *         strict_requirements?: scalar|null|Param, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
+ *         resource?: scalar|Param|null,
+ *         type?: scalar|Param|null,
+ *         default_uri?: scalar|Param|null, // The default URI used to generate URLs in a non-HTTP context. // Default: null
+ *         http_port?: scalar|Param|null, // Default: 80
+ *         https_port?: scalar|Param|null, // Default: 443
+ *         strict_requirements?: scalar|Param|null, // set to true to throw an exception when a parameter does not match the requirements set to false to disable exceptions when a parameter does not match the requirements (and return null instead) set to null to disable parameter checks against requirements 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production // Default: true
  *         utf8?: bool|Param, // Default: true
  *     },
  *     session?: bool|array{ // Session configuration
  *         enabled?: bool|Param, // Default: false
- *         storage_factory_id?: scalar|null|Param, // Default: "session.storage.factory.native"
- *         handler_id?: scalar|null|Param, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
- *         name?: scalar|null|Param,
- *         cookie_lifetime?: scalar|null|Param,
- *         cookie_path?: scalar|null|Param,
- *         cookie_domain?: scalar|null|Param,
+ *         storage_factory_id?: scalar|Param|null, // Default: "session.storage.factory.native"
+ *         handler_id?: scalar|Param|null, // Defaults to using the native session handler, or to the native *file* session handler if "save_path" is not null.
+ *         name?: scalar|Param|null,
+ *         cookie_lifetime?: scalar|Param|null,
+ *         cookie_path?: scalar|Param|null,
+ *         cookie_domain?: scalar|Param|null,
  *         cookie_secure?: true|false|"auto"|Param, // Default: "auto"
  *         cookie_httponly?: bool|Param, // Default: true
  *         cookie_samesite?: null|"lax"|"strict"|"none"|Param, // Default: "lax"
  *         use_cookies?: bool|Param,
- *         gc_divisor?: scalar|null|Param,
- *         gc_probability?: scalar|null|Param,
- *         gc_maxlifetime?: scalar|null|Param,
- *         save_path?: scalar|null|Param, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
+ *         gc_divisor?: scalar|Param|null,
+ *         gc_probability?: scalar|Param|null,
+ *         gc_maxlifetime?: scalar|Param|null,
+ *         save_path?: scalar|Param|null, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
  *         metadata_update_threshold?: int|Param, // Seconds to wait between 2 session metadata updates. // Default: 0
- *         sid_length?: int|Param, // Deprecated: Setting the "framework.session.sid_length.sid_length" configuration option is deprecated. It will be removed in version 8.0. No alternative is provided as PHP 8.4 has deprecated the related option.
- *         sid_bits_per_character?: int|Param, // Deprecated: Setting the "framework.session.sid_bits_per_character.sid_bits_per_character" configuration option is deprecated. It will be removed in version 8.0. No alternative is provided as PHP 8.4 has deprecated the related option.
  *     },
  *     request?: bool|array{ // Request configuration
  *         enabled?: bool|Param, // Default: false
- *         formats?: array<string, string|list<scalar|null|Param>>,
+ *         formats?: array<string, string|list<scalar|Param|null>>,
  *     },
  *     assets?: bool|array{ // Assets configuration
  *         enabled?: bool|Param, // Default: true
  *         strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *         version_strategy?: scalar|null|Param, // Default: null
- *         version?: scalar|null|Param, // Default: null
- *         version_format?: scalar|null|Param, // Default: "%%s?%%s"
- *         json_manifest_path?: scalar|null|Param, // Default: null
- *         base_path?: scalar|null|Param, // Default: ""
- *         base_urls?: list<scalar|null|Param>,
+ *         version_strategy?: scalar|Param|null, // Default: null
+ *         version?: scalar|Param|null, // Default: null
+ *         version_format?: scalar|Param|null, // Default: "%%s?%%s"
+ *         json_manifest_path?: scalar|Param|null, // Default: null
+ *         base_path?: scalar|Param|null, // Default: ""
+ *         base_urls?: string|list<scalar|Param|null>,
  *         packages?: array<string, array{ // Default: []
  *             strict_mode?: bool|Param, // Throw an exception if an entry is missing from the manifest.json. // Default: false
- *             version_strategy?: scalar|null|Param, // Default: null
- *             version?: scalar|null|Param,
- *             version_format?: scalar|null|Param, // Default: null
- *             json_manifest_path?: scalar|null|Param, // Default: null
- *             base_path?: scalar|null|Param, // Default: ""
- *             base_urls?: list<scalar|null|Param>,
+ *             version_strategy?: scalar|Param|null, // Default: null
+ *             version?: scalar|Param|null,
+ *             version_format?: scalar|Param|null, // Default: null
+ *             json_manifest_path?: scalar|Param|null, // Default: null
+ *             base_path?: scalar|Param|null, // Default: ""
+ *             base_urls?: string|list<scalar|Param|null>,
  *         }>,
  *     },
  *     asset_mapper?: bool|array{ // Asset Mapper configuration
  *         enabled?: bool|Param, // Default: false
- *         paths?: array<string, scalar|null|Param>,
- *         excluded_patterns?: list<scalar|null|Param>,
+ *         paths?: string|array<string, scalar|Param|null>,
+ *         excluded_patterns?: list<scalar|Param|null>,
  *         exclude_dotfiles?: bool|Param, // If true, any files starting with "." will be excluded from the asset mapper. // Default: true
  *         server?: bool|Param, // If true, a "dev server" will return the assets from the public directory (true in "debug" mode only by default). // Default: true
- *         public_prefix?: scalar|null|Param, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
+ *         public_prefix?: scalar|Param|null, // The public path where the assets will be written to (and served from when "server" is true). // Default: "/assets/"
  *         missing_import_mode?: "strict"|"warn"|"ignore"|Param, // Behavior if an asset cannot be found when imported from JavaScript or CSS files - e.g. "import './non-existent.js'". "strict" means an exception is thrown, "warn" means a warning is logged, "ignore" means the import is left as-is. // Default: "warn"
- *         extensions?: array<string, scalar|null|Param>,
- *         importmap_path?: scalar|null|Param, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
- *         importmap_polyfill?: scalar|null|Param, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
- *         importmap_script_attributes?: array<string, scalar|null|Param>,
- *         vendor_dir?: scalar|null|Param, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
+ *         extensions?: array<string, scalar|Param|null>,
+ *         importmap_path?: scalar|Param|null, // The path of the importmap.php file. // Default: "%kernel.project_dir%/importmap.php"
+ *         importmap_polyfill?: scalar|Param|null, // The importmap name that will be used to load the polyfill. Set to false to disable. // Default: "es-module-shims"
+ *         importmap_script_attributes?: array<string, scalar|Param|null>,
+ *         vendor_dir?: scalar|Param|null, // The directory to store JavaScript vendors. // Default: "%kernel.project_dir%/assets/vendor"
  *         precompress?: bool|array{ // Precompress assets with Brotli, Zstandard and gzip.
  *             enabled?: bool|Param, // Default: false
- *             formats?: list<scalar|null|Param>,
- *             extensions?: list<scalar|null|Param>,
+ *             formats?: list<scalar|Param|null>,
+ *             extensions?: list<scalar|Param|null>,
  *         },
  *     },
  *     translator?: bool|array{ // Translator configuration
  *         enabled?: bool|Param, // Default: true
- *         fallbacks?: list<scalar|null|Param>,
+ *         fallbacks?: string|list<scalar|Param|null>,
  *         logging?: bool|Param, // Default: false
- *         formatter?: scalar|null|Param, // Default: "translator.formatter.default"
- *         cache_dir?: scalar|null|Param, // Default: "%kernel.cache_dir%/translations"
- *         default_path?: scalar|null|Param, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
- *         paths?: list<scalar|null|Param>,
+ *         formatter?: scalar|Param|null, // Default: "translator.formatter.default"
+ *         cache_dir?: scalar|Param|null, // Default: "%kernel.cache_dir%/translations"
+ *         default_path?: scalar|Param|null, // The default path used to load translations. // Default: "%kernel.project_dir%/translations"
+ *         paths?: list<scalar|Param|null>,
  *         pseudo_localization?: bool|array{
  *             enabled?: bool|Param, // Default: false
  *             accents?: bool|Param, // Default: true
  *             expansion_factor?: float|Param, // Default: 1.0
  *             brackets?: bool|Param, // Default: true
  *             parse_html?: bool|Param, // Default: false
- *             localizable_html_attributes?: list<scalar|null|Param>,
+ *             localizable_html_attributes?: list<scalar|Param|null>,
  *         },
  *         providers?: array<string, array{ // Default: []
- *             dsn?: scalar|null|Param,
- *             domains?: list<scalar|null|Param>,
- *             locales?: list<scalar|null|Param>,
+ *             dsn?: scalar|Param|null,
+ *             domains?: list<scalar|Param|null>,
+ *             locales?: list<scalar|Param|null>,
  *         }>,
  *         globals?: array<string, string|array{ // Default: []
  *             value?: mixed,
  *             message?: string|Param,
- *             parameters?: array<string, scalar|null|Param>,
+ *             parameters?: array<string, scalar|Param|null>,
  *             domain?: string|Param,
  *         }>,
  *     },
  *     validation?: bool|array{ // Validation configuration
  *         enabled?: bool|Param, // Default: true
- *         cache?: scalar|null|Param, // Deprecated: Setting the "framework.validation.cache.cache" configuration option is deprecated. It will be removed in version 8.0.
  *         enable_attributes?: bool|Param, // Default: true
- *         static_method?: list<scalar|null|Param>,
- *         translation_domain?: scalar|null|Param, // Default: "validators"
- *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|"loose"|Param, // Default: "html5"
+ *         static_method?: string|list<scalar|Param|null>,
+ *         translation_domain?: scalar|Param|null, // Default: "validators"
+ *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|Param, // Default: "html5"
  *         mapping?: array{
- *             paths?: list<scalar|null|Param>,
+ *             paths?: list<scalar|Param|null>,
  *         },
  *         not_compromised_password?: bool|array{
  *             enabled?: bool|Param, // When disabled, compromised passwords will be accepted as valid. // Default: true
- *             endpoint?: scalar|null|Param, // API endpoint for the NotCompromisedPassword Validator. // Default: null
+ *             endpoint?: scalar|Param|null, // API endpoint for the NotCompromisedPassword Validator. // Default: null
  *         },
  *         disable_translation?: bool|Param, // Default: false
+ *         property_metadata_existence_check?: bool|Param, // When enabled, validateProperty() and validatePropertyValue() throw an exception if no metadata is found for the given property. // Default: false
  *         auto_mapping?: array<string, array{ // Default: []
- *             services?: list<scalar|null|Param>,
+ *             services?: list<scalar|Param|null>,
  *         }>,
- *     },
- *     annotations?: bool|array{
- *         enabled?: bool|Param, // Default: false
  *     },
  *     serializer?: bool|array{ // Serializer configuration
  *         enabled?: bool|Param, // Default: true
  *         enable_attributes?: bool|Param, // Default: true
- *         name_converter?: scalar|null|Param,
- *         circular_reference_handler?: scalar|null|Param,
- *         max_depth_handler?: scalar|null|Param,
+ *         name_converter?: scalar|Param|null,
+ *         circular_reference_handler?: scalar|Param|null,
+ *         max_depth_handler?: scalar|Param|null,
  *         mapping?: array{
- *             paths?: list<scalar|null|Param>,
+ *             paths?: list<scalar|Param|null>,
  *         },
- *         default_context?: list<mixed>,
+ *         default_context?: array<string, mixed>,
  *         named_serializers?: array<string, array{ // Default: []
- *             name_converter?: scalar|null|Param,
- *             default_context?: list<mixed>,
+ *             name_converter?: scalar|Param|null,
+ *             default_context?: array<string, mixed>,
  *             include_built_in_normalizers?: bool|Param, // Whether to include the built-in normalizers // Default: true
  *             include_built_in_encoders?: bool|Param, // Whether to include the built-in encoders // Default: true
  *         }>,
@@ -378,31 +378,32 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     type_info?: bool|array{ // Type info configuration
  *         enabled?: bool|Param, // Default: true
- *         aliases?: array<string, scalar|null|Param>,
+ *         aliases?: array<string, scalar|Param|null>,
  *     },
  *     property_info?: bool|array{ // Property info configuration
  *         enabled?: bool|Param, // Default: true
- *         with_constructor_extractor?: bool|Param, // Registers the constructor extractor.
+ *         with_constructor_extractor?: bool|Param, // Registers the constructor extractor. // Default: true
  *     },
  *     cache?: array{ // Cache configuration
- *         prefix_seed?: scalar|null|Param, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
- *         app?: scalar|null|Param, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
- *         system?: scalar|null|Param, // System related cache pools configuration. // Default: "cache.adapter.system"
- *         directory?: scalar|null|Param, // Default: "%kernel.share_dir%/pools/app"
- *         default_psr6_provider?: scalar|null|Param,
- *         default_redis_provider?: scalar|null|Param, // Default: "redis://localhost"
- *         default_valkey_provider?: scalar|null|Param, // Default: "valkey://localhost"
- *         default_memcached_provider?: scalar|null|Param, // Default: "memcached://localhost"
- *         default_doctrine_dbal_provider?: scalar|null|Param, // Default: "database_connection"
- *         default_pdo_provider?: scalar|null|Param, // Default: null
+ *         prefix_seed?: scalar|Param|null, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
+ *         app?: scalar|Param|null, // App related cache pools configuration. // Default: "cache.adapter.filesystem"
+ *         system?: scalar|Param|null, // System related cache pools configuration. // Default: "cache.adapter.system"
+ *         directory?: scalar|Param|null, // Default: "%kernel.share_dir%/pools/app"
+ *         default_psr6_provider?: scalar|Param|null,
+ *         default_redis_provider?: scalar|Param|null, // Default: "redis://localhost"
+ *         default_valkey_provider?: scalar|Param|null, // Default: "valkey://localhost"
+ *         default_memcached_provider?: scalar|Param|null, // Default: "memcached://localhost"
+ *         default_doctrine_dbal_provider?: scalar|Param|null, // Default: "database_connection"
+ *         default_pdo_provider?: scalar|Param|null, // Default: null
  *         pools?: array<string, array{ // Default: []
- *             adapters?: list<scalar|null|Param>,
- *             tags?: scalar|null|Param, // Default: null
+ *             adapters?: string|list<scalar|Param|null>,
+ *             tags?: scalar|Param|null, // Default: null
  *             public?: bool|Param, // Default: false
- *             default_lifetime?: scalar|null|Param, // Default lifetime of the pool.
- *             provider?: scalar|null|Param, // Overwrite the setting from the default provider for this adapter.
- *             early_expiration_message_bus?: scalar|null|Param,
- *             clearer?: scalar|null|Param,
+ *             default_lifetime?: scalar|Param|null, // Default lifetime of the pool.
+ *             provider?: scalar|Param|null, // Overwrite the setting from the default provider for this adapter.
+ *             early_expiration_message_bus?: scalar|Param|null,
+ *             clearer?: scalar|Param|null,
+ *             marshaller?: scalar|Param|null, // The marshaller service to use for this pool.
  *         }>,
  *     },
  *     php_errors?: array{ // PHP errors handling configuration
@@ -410,59 +411,57 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         throw?: bool|Param, // Throw PHP errors as \ErrorException instances. // Default: true
  *     },
  *     exceptions?: array<string, array{ // Default: []
- *         log_level?: scalar|null|Param, // The level of log message. Null to let Symfony decide. // Default: null
- *         status_code?: scalar|null|Param, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
- *         log_channel?: scalar|null|Param, // The channel of log message. Null to let Symfony decide. // Default: null
+ *         log_level?: scalar|Param|null, // The level of log message. Null to let Symfony decide. // Default: null
+ *         status_code?: scalar|Param|null, // The status code of the response. Null or 0 to let Symfony decide. // Default: null
+ *         log_channel?: scalar|Param|null, // The channel of log message. Null to let Symfony decide. // Default: null
  *     }>,
  *     web_link?: bool|array{ // Web links configuration
  *         enabled?: bool|Param, // Default: true
  *     },
  *     lock?: bool|string|array{ // Lock configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: array<string, string|list<scalar|null|Param>>,
+ *         resources?: string|array<string, string|list<scalar|Param|null>>,
  *     },
  *     semaphore?: bool|string|array{ // Semaphore configuration
  *         enabled?: bool|Param, // Default: false
- *         resources?: array<string, scalar|null|Param>,
+ *         resources?: string|array<string, scalar|Param|null>,
  *     },
  *     messenger?: bool|array{ // Messenger configuration
  *         enabled?: bool|Param, // Default: true
- *         routing?: array<string, array{ // Default: []
- *             senders?: list<scalar|null|Param>,
- *         }>,
+ *         routing?: array<string, string|list<scalar|Param|null>>,
  *         serializer?: array{
- *             default_serializer?: scalar|null|Param, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
+ *             default_serializer?: scalar|Param|null, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
  *             symfony_serializer?: array{
- *                 format?: scalar|null|Param, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
+ *                 format?: scalar|Param|null, // Serialization format for the messenger.transport.symfony_serializer service (which is not the serializer used by default). // Default: "json"
  *                 context?: array<string, mixed>,
  *             },
  *         },
  *         transports?: array<string, string|array{ // Default: []
- *             dsn?: scalar|null|Param,
- *             serializer?: scalar|null|Param, // Service id of a custom serializer to use. // Default: null
- *             options?: list<mixed>,
- *             failure_transport?: scalar|null|Param, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *             dsn?: scalar|Param|null,
+ *             serializer?: scalar|Param|null, // Service id of a custom serializer to use. // Default: null
+ *             options?: array<string, mixed>,
+ *             failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
  *             retry_strategy?: string|array{
- *                 service?: scalar|null|Param, // Service id to override the retry strategy entirely. // Default: null
+ *                 service?: scalar|Param|null, // Service id to override the retry strategy entirely. // Default: null
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
  *                 multiplier?: float|Param, // If greater than 1, delay will grow exponentially for each retry: this delay = (delay * (multiple ^ retries)). // Default: 2
  *                 max_delay?: int|Param, // Max time in ms that a retry should ever be delayed (0 = infinite). // Default: 0
  *                 jitter?: float|Param, // Randomness to apply to the delay (between 0 and 1). // Default: 0.1
  *             },
- *             rate_limiter?: scalar|null|Param, // Rate limiter name to use when processing messages. // Default: null
+ *             rate_limiter?: scalar|Param|null, // Rate limiter name to use when processing messages. // Default: null
  *         }>,
- *         failure_transport?: scalar|null|Param, // Transport name to send failed messages to (after all retries have failed). // Default: null
- *         stop_worker_on_signals?: list<scalar|null|Param>,
- *         default_bus?: scalar|null|Param, // Default: null
+ *         failure_transport?: scalar|Param|null, // Transport name to send failed messages to (after all retries have failed). // Default: null
+ *         stop_worker_on_signals?: int|string|list<scalar|Param|null>,
+ *         default_bus?: scalar|Param|null, // Default: null
  *         buses?: array<string, array{ // Default: {"messenger.bus.default":{"default_middleware":{"enabled":true,"allow_no_handlers":false,"allow_no_senders":true},"middleware":[]}}
  *             default_middleware?: bool|string|array{
  *                 enabled?: bool|Param, // Default: true
  *                 allow_no_handlers?: bool|Param, // Default: false
  *                 allow_no_senders?: bool|Param, // Default: true
  *             },
- *             middleware?: list<string|array{ // Default: []
- *                 id: scalar|null|Param,
+ *             middleware?: string|list<string|array{ // Default: []
+ *                 id?: scalar|Param|null,
  *                 arguments?: list<mixed>,
  *             }>,
  *         }>,
@@ -478,41 +477,41 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             headers?: array<string, mixed>,
  *             vars?: array<string, mixed>,
  *             max_redirects?: int|Param, // The maximum number of redirects to follow.
- *             http_version?: scalar|null|Param, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|null|Param>,
- *             proxy?: scalar|null|Param, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|null|Param, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|Param|null>,
+ *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
  *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
  *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|null|Param, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
  *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
  *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|null|Param, // A certificate authority file.
- *             capath?: scalar|null|Param, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|null|Param, // A PEM formatted certificate file.
- *             local_pk?: scalar|null|Param, // A private key file.
- *             passphrase?: scalar|null|Param, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|null|Param, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
+ *             cafile?: scalar|Param|null, // A certificate authority file.
+ *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
+ *             local_pk?: scalar|Param|null, // A private key file.
+ *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...)
  *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
  *                 sha1?: mixed,
  *                 pin-sha256?: mixed,
  *                 md5?: mixed,
  *             },
- *             crypto_method?: scalar|null|Param, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
  *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|null|Param, // Rate limiter name to use for throttling requests. // Default: null
+ *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
  *                 enabled?: bool|Param, // Default: false
  *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
  *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
- *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. // Default: 86400
  *             },
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
- *                 retry_strategy?: scalar|null|Param, // service id to override the retry strategy. // Default: null
- *                 http_codes?: array<string, array{ // Default: []
+ *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                 http_codes?: int|string|array<string, array{ // Default: []
  *                     code?: int|Param,
- *                     methods?: list<string|Param>,
+ *                     methods?: string|list<string|Param>,
  *                 }>,
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
@@ -521,51 +520,52 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
  *             },
  *         },
- *         mock_response_factory?: scalar|null|Param, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
+ *         mock_response_factory?: scalar|Param|null, // `true` to always return empty 200 responses, or the id of the service to use to generate mock responses - which should be either an invokable or an iterable.
  *         scoped_clients?: array<string, string|array{ // Default: []
- *             scope?: scalar|null|Param, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
- *             base_uri?: scalar|null|Param, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
- *             auth_basic?: scalar|null|Param, // An HTTP Basic authentication "username:password".
- *             auth_bearer?: scalar|null|Param, // A token enabling HTTP Bearer authorization.
- *             auth_ntlm?: scalar|null|Param, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
- *             query?: array<string, scalar|null|Param>,
+ *             scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
+ *             base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
+ *             auth_basic?: scalar|Param|null, // An HTTP Basic authentication "username:password".
+ *             auth_bearer?: scalar|Param|null, // A token enabling HTTP Bearer authorization.
+ *             auth_ntlm?: scalar|Param|null, // A "username:password" pair to use Microsoft NTLM authentication (requires the cURL extension).
+ *             query?: array<string, scalar|Param|null>,
  *             headers?: array<string, mixed>,
  *             max_redirects?: int|Param, // The maximum number of redirects to follow.
- *             http_version?: scalar|null|Param, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
- *             resolve?: array<string, scalar|null|Param>,
- *             proxy?: scalar|null|Param, // The URL of the proxy to pass requests through or null for automatic detection.
- *             no_proxy?: scalar|null|Param, // A comma separated list of hosts that do not require a proxy to be reached.
+ *             http_version?: scalar|Param|null, // The default HTTP version, typically 1.1 or 2.0, leave to null for the best version.
+ *             resolve?: array<string, scalar|Param|null>,
+ *             proxy?: scalar|Param|null, // The URL of the proxy to pass requests through or null for automatic detection.
+ *             no_proxy?: scalar|Param|null, // A comma separated list of hosts that do not require a proxy to be reached.
  *             timeout?: float|Param, // The idle timeout, defaults to the "default_socket_timeout" ini parameter.
  *             max_duration?: float|Param, // The maximum execution time for the request+response as a whole.
- *             bindto?: scalar|null|Param, // A network interface name, IP address, a host name or a UNIX socket to bind to.
+ *             bindto?: scalar|Param|null, // A network interface name, IP address, a host name or a UNIX socket to bind to.
  *             verify_peer?: bool|Param, // Indicates if the peer should be verified in a TLS context.
  *             verify_host?: bool|Param, // Indicates if the host should exist as a certificate common name.
- *             cafile?: scalar|null|Param, // A certificate authority file.
- *             capath?: scalar|null|Param, // A directory that contains multiple certificate authority files.
- *             local_cert?: scalar|null|Param, // A PEM formatted certificate file.
- *             local_pk?: scalar|null|Param, // A private key file.
- *             passphrase?: scalar|null|Param, // The passphrase used to encrypt the "local_pk" file.
- *             ciphers?: scalar|null|Param, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
+ *             cafile?: scalar|Param|null, // A certificate authority file.
+ *             capath?: scalar|Param|null, // A directory that contains multiple certificate authority files.
+ *             local_cert?: scalar|Param|null, // A PEM formatted certificate file.
+ *             local_pk?: scalar|Param|null, // A private key file.
+ *             passphrase?: scalar|Param|null, // The passphrase used to encrypt the "local_pk" file.
+ *             ciphers?: scalar|Param|null, // A list of TLS ciphers separated by colons, commas or spaces (e.g. "RC3-SHA:TLS13-AES-128-GCM-SHA256"...).
  *             peer_fingerprint?: array{ // Associative array: hashing algorithm => hash(es).
  *                 sha1?: mixed,
  *                 pin-sha256?: mixed,
  *                 md5?: mixed,
  *             },
- *             crypto_method?: scalar|null|Param, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             mock_response_factory?: scalar|Param|null, // `true` to always return empty 200 responses, `false` to disable mocking, or the id of the service to use to generate mock responses (invokable or iterable).
  *             extra?: array<string, mixed>,
- *             rate_limiter?: scalar|null|Param, // Rate limiter name to use for throttling requests. // Default: null
+ *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
  *                 enabled?: bool|Param, // Default: false
  *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
  *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
- *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. // Default: 86400
  *             },
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
- *                 retry_strategy?: scalar|null|Param, // service id to override the retry strategy. // Default: null
- *                 http_codes?: array<string, array{ // Default: []
+ *                 retry_strategy?: scalar|Param|null, // service id to override the retry strategy. // Default: null
+ *                 http_codes?: int|string|array<string, array{ // Default: []
  *                     code?: int|Param,
- *                     methods?: list<string|Param>,
+ *                     methods?: string|list<string|Param>,
  *                 }>,
  *                 max_retries?: int|Param, // Default: 3
  *                 delay?: int|Param, // Time in ms to delay (or the initial value when multiplier is used). // Default: 1000
@@ -577,110 +577,117 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     mailer?: bool|array{ // Mailer configuration
  *         enabled?: bool|Param, // Default: true
- *         message_bus?: scalar|null|Param, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
- *         dsn?: scalar|null|Param, // Default: null
- *         transports?: array<string, scalar|null|Param>,
+ *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         dsn?: scalar|Param|null, // Default: null
+ *         transports?: array<string, scalar|Param|null>,
  *         envelope?: array{ // Mailer Envelope configuration
- *             sender?: scalar|null|Param,
- *             recipients?: list<scalar|null|Param>,
- *             allowed_recipients?: list<scalar|null|Param>,
+ *             sender?: scalar|Param|null,
+ *             recipients?: string|list<scalar|Param|null>,
+ *             allowed_recipients?: string|list<scalar|Param|null>,
  *         },
  *         headers?: array<string, string|array{ // Default: []
  *             value?: mixed,
  *         }>,
  *         dkim_signer?: bool|array{ // DKIM signer configuration
  *             enabled?: bool|Param, // Default: false
- *             key?: scalar|null|Param, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
- *             domain?: scalar|null|Param, // Default: ""
- *             select?: scalar|null|Param, // Default: ""
- *             passphrase?: scalar|null|Param, // The private key passphrase // Default: ""
+ *             key?: scalar|Param|null, // Key content, or path to key (in PEM format with the `file://` prefix) // Default: ""
+ *             domain?: scalar|Param|null, // Default: ""
+ *             select?: scalar|Param|null, // Default: ""
+ *             passphrase?: scalar|Param|null, // The private key passphrase // Default: ""
  *             options?: array<string, mixed>,
  *         },
  *         smime_signer?: bool|array{ // S/MIME signer configuration
  *             enabled?: bool|Param, // Default: false
- *             key?: scalar|null|Param, // Path to key (in PEM format) // Default: ""
- *             certificate?: scalar|null|Param, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
- *             passphrase?: scalar|null|Param, // The private key passphrase // Default: null
- *             extra_certificates?: scalar|null|Param, // Default: null
+ *             key?: scalar|Param|null, // Path to key (in PEM format) // Default: ""
+ *             certificate?: scalar|Param|null, // Path to certificate (in PEM format without the `file://` prefix) // Default: ""
+ *             passphrase?: scalar|Param|null, // The private key passphrase // Default: null
+ *             extra_certificates?: scalar|Param|null, // Default: null
  *             sign_options?: int|Param, // Default: null
  *         },
  *         smime_encrypter?: bool|array{ // S/MIME encrypter configuration
  *             enabled?: bool|Param, // Default: false
- *             repository?: scalar|null|Param, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
+ *             repository?: scalar|Param|null, // S/MIME certificate repository service. This service shall implement the `Symfony\Component\Mailer\EventListener\SmimeCertificateRepositoryInterface`. // Default: ""
  *             cipher?: int|Param, // A set of algorithms used to encrypt the message // Default: null
  *         },
  *     },
  *     secrets?: bool|array{
  *         enabled?: bool|Param, // Default: true
- *         vault_directory?: scalar|null|Param, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
- *         local_dotenv_file?: scalar|null|Param, // Default: "%kernel.project_dir%/.env.%kernel.runtime_environment%.local"
- *         decryption_env_var?: scalar|null|Param, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
+ *         vault_directory?: scalar|Param|null, // Default: "%kernel.project_dir%/config/secrets/%kernel.runtime_environment%"
+ *         local_dotenv_file?: scalar|Param|null, // Default: "%kernel.project_dir%/.env.%kernel.environment%.local"
+ *         decryption_env_var?: scalar|Param|null, // Default: "base64:default::SYMFONY_DECRYPTION_SECRET"
  *     },
  *     notifier?: bool|array{ // Notifier configuration
  *         enabled?: bool|Param, // Default: false
- *         message_bus?: scalar|null|Param, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
- *         chatter_transports?: array<string, scalar|null|Param>,
- *         texter_transports?: array<string, scalar|null|Param>,
+ *         message_bus?: scalar|Param|null, // The message bus to use. Defaults to the default bus if the Messenger component is installed. // Default: null
+ *         chatter_transports?: array<string, scalar|Param|null>,
+ *         texter_transports?: array<string, scalar|Param|null>,
  *         notification_on_failed_messages?: bool|Param, // Default: false
- *         channel_policy?: array<string, string|list<scalar|null|Param>>,
+ *         channel_policy?: array<string, string|list<scalar|Param|null>>,
  *         admin_recipients?: list<array{ // Default: []
- *             email?: scalar|null|Param,
- *             phone?: scalar|null|Param, // Default: ""
+ *             email?: scalar|Param|null,
+ *             phone?: scalar|Param|null, // Default: ""
  *         }>,
  *     },
  *     rate_limiter?: bool|array{ // Rate limiter configuration
  *         enabled?: bool|Param, // Default: true
  *         limiters?: array<string, array{ // Default: []
- *             lock_factory?: scalar|null|Param, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
- *             cache_pool?: scalar|null|Param, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
- *             storage_service?: scalar|null|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
- *             policy: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
- *             limiters?: list<scalar|null|Param>,
+ *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by this limiter (or null to disable locking). // Default: "auto"
+ *             cache_pool?: scalar|Param|null, // The cache pool to use for storing the current limiter state. // Default: "cache.rate_limiter"
+ *             storage_service?: scalar|Param|null, // The service ID of a custom storage implementation, this precedes any configured "cache_pool". // Default: null
+ *             policy?: "fixed_window"|"token_bucket"|"sliding_window"|"compound"|"no_limit"|Param, // The algorithm to be used by this limiter.
+ *             limiters?: string|list<scalar|Param|null>,
  *             limit?: int|Param, // The maximum allowed hits in a fixed interval or burst.
- *             interval?: scalar|null|Param, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *             interval?: scalar|Param|null, // Configures the fixed interval if "policy" is set to "fixed_window" or "sliding_window". The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *             rate?: array{ // Configures the fill rate if "policy" is set to "token_bucket".
- *                 interval?: scalar|null|Param, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
+ *                 interval?: scalar|Param|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *                 amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
  *             },
+ *             anchor_at?: scalar|Param|null, // Aligns the "fixed_window" policy to a calendar (e.g. "2024-01-05 00:00:00 UTC" combined with `interval: 1 month` resets the counter on the 5th of each month). UTC if not specified. // Default: null
  *         }>,
  *     },
  *     uid?: bool|array{ // Uid configuration
  *         enabled?: bool|Param, // Default: true
  *         default_uuid_version?: 7|6|4|1|Param, // Default: 7
  *         name_based_uuid_version?: 5|3|Param, // Default: 5
- *         name_based_uuid_namespace?: scalar|null|Param,
+ *         name_based_uuid_namespace?: scalar|Param|null,
  *         time_based_uuid_version?: 7|6|1|Param, // Default: 7
- *         time_based_uuid_node?: scalar|null|Param,
+ *         time_based_uuid_node?: scalar|Param|null,
+ *         uuid47_secret?: scalar|Param|null, // A high-entropy secret used by the "uuid47_transformer" service. Defaults to "kernel.secret". // Default: null
  *     },
  *     html_sanitizer?: bool|array{ // HtmlSanitizer configuration
  *         enabled?: bool|Param, // Default: false
  *         sanitizers?: array<string, array{ // Default: []
+ *             default_action?: "drop"|"block"|"allow"|Param, // Defines how the sanitizer must behave by default.
  *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
  *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
  *             allow_elements?: array<string, mixed>,
- *             block_elements?: list<string|Param>,
- *             drop_elements?: list<string|Param>,
+ *             block_elements?: string|list<string|Param>,
+ *             drop_elements?: string|list<string|Param>,
  *             allow_attributes?: array<string, mixed>,
  *             drop_attributes?: array<string, mixed>,
  *             force_attributes?: array<string, array<string, string|Param>>,
  *             force_https_urls?: bool|Param, // Transforms URLs using the HTTP scheme to use the HTTPS scheme instead. // Default: false
- *             allowed_link_schemes?: list<string|Param>,
- *             allowed_link_hosts?: list<string|Param>|null,
+ *             allowed_link_schemes?: string|list<string|Param>,
+ *             allowed_link_hosts?: null|string|list<string|Param>,
  *             allow_relative_links?: bool|Param, // Allows relative URLs to be used in links href attributes. // Default: false
- *             allowed_media_schemes?: list<string|Param>,
- *             allowed_media_hosts?: list<string|Param>|null,
+ *             allowed_media_schemes?: string|list<string|Param>,
+ *             allowed_media_hosts?: null|string|list<string|Param>,
  *             allow_relative_medias?: bool|Param, // Allows relative URLs to be used in media source attributes (img, audio, video, ...). // Default: false
- *             with_attribute_sanitizers?: list<string|Param>,
- *             without_attribute_sanitizers?: list<string|Param>,
+ *             with_attribute_sanitizers?: string|list<string|Param>,
+ *             without_attribute_sanitizers?: string|list<string|Param>,
  *             max_input_length?: int|Param, // The maximum length allowed for the sanitized input. // Default: 0
  *         }>,
  *     },
  *     webhook?: bool|array{ // Webhook configuration
  *         enabled?: bool|Param, // Default: false
- *         message_bus?: scalar|null|Param, // The message bus to use. // Default: "messenger.default_bus"
+ *         message_bus?: scalar|Param|null, // The message bus to use. // Default: "messenger.default_bus"
+ *         event_header_name?: scalar|Param|null, // Default: "Webhook-Event"
+ *         id_header_name?: scalar|Param|null, // Default: "Webhook-Id"
+ *         signature_header_name?: scalar|Param|null, // Default: "Webhook-Signature"
+ *         signing_algorithm?: scalar|Param|null, // Default: "sha256"
  *         routing?: array<string, array{ // Default: []
- *             service: scalar|null|Param,
- *             secret?: scalar|null|Param, // Default: ""
+ *             service?: scalar|Param|null,
+ *             secret?: scalar|Param|null, // Default: ""
  *         }>,
  *     },
  *     remote-event?: bool|array{ // RemoteEvent configuration
@@ -688,182 +695,185 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     json_streamer?: bool|array{ // JSON streamer configuration
  *         enabled?: bool|Param, // Default: false
+ *         default_options?: array{
+ *             include_null_properties?: bool|Param, // Encode the properties with null value // Default: false
+ *             ...<string, mixed>
+ *         },
  *     },
  * }
  * @psalm-type MonologConfig = array{
- *     use_microseconds?: scalar|null|Param, // Default: true
- *     channels?: list<scalar|null|Param>,
+ *     use_microseconds?: scalar|Param|null, // Default: true
+ *     channels?: list<scalar|Param|null>,
  *     handlers?: array<string, array{ // Default: []
- *         type: scalar|null|Param,
- *         id?: scalar|null|Param,
+ *         type?: scalar|Param|null,
+ *         id?: scalar|Param|null,
  *         enabled?: bool|Param, // Default: true
- *         priority?: scalar|null|Param, // Default: 0
- *         level?: scalar|null|Param, // Default: "DEBUG"
+ *         priority?: scalar|Param|null, // Default: 0
+ *         level?: scalar|Param|null, // Default: "DEBUG"
  *         bubble?: bool|Param, // Default: true
  *         interactive_only?: bool|Param, // Default: false
- *         app_name?: scalar|null|Param, // Default: null
+ *         app_name?: scalar|Param|null, // Default: null
  *         include_stacktraces?: bool|Param, // Default: false
  *         process_psr_3_messages?: array{
- *             enabled?: bool|null|Param, // Default: null
- *             date_format?: scalar|null|Param,
+ *             enabled?: bool|Param|null, // Default: null
+ *             date_format?: scalar|Param|null,
  *             remove_used_context_fields?: bool|Param,
  *         },
- *         path?: scalar|null|Param, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
- *         file_permission?: scalar|null|Param, // Default: null
+ *         path?: scalar|Param|null, // Default: "%kernel.logs_dir%/%kernel.environment%.log"
+ *         file_permission?: scalar|Param|null, // Default: null
  *         use_locking?: bool|Param, // Default: false
- *         filename_format?: scalar|null|Param, // Default: "{filename}-{date}"
- *         date_format?: scalar|null|Param, // Default: "Y-m-d"
- *         ident?: scalar|null|Param, // Default: false
- *         logopts?: scalar|null|Param, // Default: 1
- *         facility?: scalar|null|Param, // Default: "user"
- *         max_files?: scalar|null|Param, // Default: 0
- *         action_level?: scalar|null|Param, // Default: "WARNING"
- *         activation_strategy?: scalar|null|Param, // Default: null
+ *         filename_format?: scalar|Param|null, // Default: "{filename}-{date}"
+ *         date_format?: scalar|Param|null, // Default: "Y-m-d"
+ *         ident?: scalar|Param|null, // Default: false
+ *         logopts?: scalar|Param|null, // Default: 1
+ *         facility?: scalar|Param|null, // Default: "user"
+ *         max_files?: scalar|Param|null, // Default: 0
+ *         action_level?: scalar|Param|null, // Default: "WARNING"
+ *         activation_strategy?: scalar|Param|null, // Default: null
  *         stop_buffering?: bool|Param, // Default: true
- *         passthru_level?: scalar|null|Param, // Default: null
+ *         passthru_level?: scalar|Param|null, // Default: null
  *         excluded_http_codes?: list<array{ // Default: []
- *             code?: scalar|null|Param,
- *             urls?: list<scalar|null|Param>,
+ *             code?: scalar|Param|null,
+ *             urls?: list<scalar|Param|null>,
  *         }>,
- *         accepted_levels?: list<scalar|null|Param>,
- *         min_level?: scalar|null|Param, // Default: "DEBUG"
- *         max_level?: scalar|null|Param, // Default: "EMERGENCY"
- *         buffer_size?: scalar|null|Param, // Default: 0
+ *         accepted_levels?: list<scalar|Param|null>,
+ *         min_level?: scalar|Param|null, // Default: "DEBUG"
+ *         max_level?: scalar|Param|null, // Default: "EMERGENCY"
+ *         buffer_size?: scalar|Param|null, // Default: 0
  *         flush_on_overflow?: bool|Param, // Default: false
- *         handler?: scalar|null|Param,
- *         url?: scalar|null|Param,
- *         exchange?: scalar|null|Param,
- *         exchange_name?: scalar|null|Param, // Default: "log"
- *         channel?: scalar|null|Param, // Default: null
- *         bot_name?: scalar|null|Param, // Default: "Monolog"
- *         use_attachment?: scalar|null|Param, // Default: true
- *         use_short_attachment?: scalar|null|Param, // Default: false
- *         include_extra?: scalar|null|Param, // Default: false
- *         icon_emoji?: scalar|null|Param, // Default: null
- *         webhook_url?: scalar|null|Param,
- *         exclude_fields?: list<scalar|null|Param>,
- *         token?: scalar|null|Param,
- *         region?: scalar|null|Param,
- *         source?: scalar|null|Param,
+ *         handler?: scalar|Param|null,
+ *         url?: scalar|Param|null,
+ *         exchange?: scalar|Param|null,
+ *         exchange_name?: scalar|Param|null, // Default: "log"
+ *         channel?: scalar|Param|null, // Default: null
+ *         bot_name?: scalar|Param|null, // Default: "Monolog"
+ *         use_attachment?: scalar|Param|null, // Default: true
+ *         use_short_attachment?: scalar|Param|null, // Default: false
+ *         include_extra?: scalar|Param|null, // Default: false
+ *         icon_emoji?: scalar|Param|null, // Default: null
+ *         webhook_url?: scalar|Param|null,
+ *         exclude_fields?: list<scalar|Param|null>,
+ *         token?: scalar|Param|null,
+ *         region?: scalar|Param|null,
+ *         source?: scalar|Param|null,
  *         use_ssl?: bool|Param, // Default: true
  *         user?: mixed,
- *         title?: scalar|null|Param, // Default: null
- *         host?: scalar|null|Param, // Default: null
- *         port?: scalar|null|Param, // Default: 514
- *         config?: list<scalar|null|Param>,
- *         members?: list<scalar|null|Param>,
- *         connection_string?: scalar|null|Param,
- *         timeout?: scalar|null|Param,
- *         time?: scalar|null|Param, // Default: 60
- *         deduplication_level?: scalar|null|Param, // Default: 400
- *         store?: scalar|null|Param, // Default: null
- *         connection_timeout?: scalar|null|Param,
+ *         title?: scalar|Param|null, // Default: null
+ *         host?: scalar|Param|null, // Default: null
+ *         port?: scalar|Param|null, // Default: 514
+ *         config?: list<scalar|Param|null>,
+ *         members?: list<scalar|Param|null>,
+ *         connection_string?: scalar|Param|null,
+ *         timeout?: scalar|Param|null,
+ *         time?: scalar|Param|null, // Default: 60
+ *         deduplication_level?: scalar|Param|null, // Default: 400
+ *         store?: scalar|Param|null, // Default: null
+ *         connection_timeout?: scalar|Param|null,
  *         persistent?: bool|Param,
- *         message_type?: scalar|null|Param, // Default: 0
- *         parse_mode?: scalar|null|Param, // Default: null
- *         disable_webpage_preview?: bool|null|Param, // Default: null
- *         disable_notification?: bool|null|Param, // Default: null
+ *         message_type?: scalar|Param|null, // Default: 0
+ *         parse_mode?: scalar|Param|null, // Default: null
+ *         disable_webpage_preview?: bool|Param|null, // Default: null
+ *         disable_notification?: bool|Param|null, // Default: null
  *         split_long_messages?: bool|Param, // Default: false
  *         delay_between_messages?: bool|Param, // Default: false
  *         topic?: int|Param, // Default: null
  *         factor?: int|Param, // Default: 1
- *         tags?: list<scalar|null|Param>,
+ *         tags?: string|list<scalar|Param|null>,
  *         console_formatter_options?: mixed, // Default: []
- *         formatter?: scalar|null|Param,
+ *         formatter?: scalar|Param|null,
  *         nested?: bool|Param, // Default: false
  *         publisher?: string|array{
- *             id?: scalar|null|Param,
- *             hostname?: scalar|null|Param,
- *             port?: scalar|null|Param, // Default: 12201
- *             chunk_size?: scalar|null|Param, // Default: 1420
+ *             id?: scalar|Param|null,
+ *             hostname?: scalar|Param|null,
+ *             port?: scalar|Param|null, // Default: 12201
+ *             chunk_size?: scalar|Param|null, // Default: 1420
  *             encoder?: "json"|"compressed_json"|Param,
  *         },
  *         mongodb?: string|array{
- *             id?: scalar|null|Param, // ID of a MongoDB\Client service
- *             uri?: scalar|null|Param,
- *             username?: scalar|null|Param,
- *             password?: scalar|null|Param,
- *             database?: scalar|null|Param, // Default: "monolog"
- *             collection?: scalar|null|Param, // Default: "logs"
+ *             id?: scalar|Param|null, // ID of a MongoDB\Client service
+ *             uri?: scalar|Param|null,
+ *             username?: scalar|Param|null,
+ *             password?: scalar|Param|null,
+ *             database?: scalar|Param|null, // Default: "monolog"
+ *             collection?: scalar|Param|null, // Default: "logs"
  *         },
  *         elasticsearch?: string|array{
- *             id?: scalar|null|Param,
- *             hosts?: list<scalar|null|Param>,
- *             host?: scalar|null|Param,
- *             port?: scalar|null|Param, // Default: 9200
- *             transport?: scalar|null|Param, // Default: "Http"
- *             user?: scalar|null|Param, // Default: null
- *             password?: scalar|null|Param, // Default: null
+ *             id?: scalar|Param|null,
+ *             hosts?: list<scalar|Param|null>,
+ *             host?: scalar|Param|null,
+ *             port?: scalar|Param|null, // Default: 9200
+ *             transport?: scalar|Param|null, // Default: "Http"
+ *             user?: scalar|Param|null, // Default: null
+ *             password?: scalar|Param|null, // Default: null
  *         },
- *         index?: scalar|null|Param, // Default: "monolog"
- *         document_type?: scalar|null|Param, // Default: "logs"
- *         ignore_error?: scalar|null|Param, // Default: false
+ *         index?: scalar|Param|null, // Default: "monolog"
+ *         document_type?: scalar|Param|null, // Default: "logs"
+ *         ignore_error?: scalar|Param|null, // Default: false
  *         redis?: string|array{
- *             id?: scalar|null|Param,
- *             host?: scalar|null|Param,
- *             password?: scalar|null|Param, // Default: null
- *             port?: scalar|null|Param, // Default: 6379
- *             database?: scalar|null|Param, // Default: 0
- *             key_name?: scalar|null|Param, // Default: "monolog_redis"
+ *             id?: scalar|Param|null,
+ *             host?: scalar|Param|null,
+ *             password?: scalar|Param|null, // Default: null
+ *             port?: scalar|Param|null, // Default: 6379
+ *             database?: scalar|Param|null, // Default: 0
+ *             key_name?: scalar|Param|null, // Default: "monolog_redis"
  *         },
  *         predis?: string|array{
- *             id?: scalar|null|Param,
- *             host?: scalar|null|Param,
+ *             id?: scalar|Param|null,
+ *             host?: scalar|Param|null,
  *         },
- *         from_email?: scalar|null|Param,
- *         to_email?: list<scalar|null|Param>,
- *         subject?: scalar|null|Param,
- *         content_type?: scalar|null|Param, // Default: null
- *         headers?: list<scalar|null|Param>,
- *         mailer?: scalar|null|Param, // Default: null
+ *         from_email?: scalar|Param|null,
+ *         to_email?: string|list<scalar|Param|null>,
+ *         subject?: scalar|Param|null,
+ *         content_type?: scalar|Param|null, // Default: null
+ *         headers?: list<scalar|Param|null>,
+ *         mailer?: scalar|Param|null, // Default: null
  *         email_prototype?: string|array{
- *             id: scalar|null|Param,
- *             method?: scalar|null|Param, // Default: null
+ *             id?: scalar|Param|null,
+ *             method?: scalar|Param|null, // Default: null
  *         },
  *         verbosity_levels?: array{
- *             VERBOSITY_QUIET?: scalar|null|Param, // Default: "ERROR"
- *             VERBOSITY_NORMAL?: scalar|null|Param, // Default: "WARNING"
- *             VERBOSITY_VERBOSE?: scalar|null|Param, // Default: "NOTICE"
- *             VERBOSITY_VERY_VERBOSE?: scalar|null|Param, // Default: "INFO"
- *             VERBOSITY_DEBUG?: scalar|null|Param, // Default: "DEBUG"
+ *             VERBOSITY_QUIET?: scalar|Param|null, // Default: "ERROR"
+ *             VERBOSITY_NORMAL?: scalar|Param|null, // Default: "WARNING"
+ *             VERBOSITY_VERBOSE?: scalar|Param|null, // Default: "NOTICE"
+ *             VERBOSITY_VERY_VERBOSE?: scalar|Param|null, // Default: "INFO"
+ *             VERBOSITY_DEBUG?: scalar|Param|null, // Default: "DEBUG"
  *         },
  *         channels?: string|array{
- *             type?: scalar|null|Param,
- *             elements?: list<scalar|null|Param>,
+ *             type?: scalar|Param|null,
+ *             elements?: list<scalar|Param|null>,
  *         },
  *     }>,
  * }
  * @psalm-type TwigConfig = array{
- *     form_themes?: list<scalar|null|Param>,
+ *     form_themes?: list<scalar|Param|null>,
  *     globals?: array<string, array{ // Default: []
- *         id?: scalar|null|Param,
- *         type?: scalar|null|Param,
+ *         id?: scalar|Param|null,
+ *         type?: scalar|Param|null,
  *         value?: mixed,
  *     }>,
- *     autoescape_service?: scalar|null|Param, // Default: null
- *     autoescape_service_method?: scalar|null|Param, // Default: null
- *     base_template_class?: scalar|null|Param, // Deprecated: The child node "base_template_class" at path "twig.base_template_class" is deprecated.
- *     cache?: scalar|null|Param, // Default: true
- *     charset?: scalar|null|Param, // Default: "%kernel.charset%"
+ *     autoescape_service?: scalar|Param|null, // Default: null
+ *     autoescape_service_method?: scalar|Param|null, // Default: null
+ *     cache?: scalar|Param|null, // Default: true
+ *     charset?: scalar|Param|null, // Default: "%kernel.charset%"
  *     debug?: bool|Param, // Default: "%kernel.debug%"
  *     strict_variables?: bool|Param, // Default: "%kernel.debug%"
- *     auto_reload?: scalar|null|Param,
+ *     auto_reload?: scalar|Param|null,
  *     optimizations?: int|Param,
- *     default_path?: scalar|null|Param, // The default path used to load templates. // Default: "%kernel.project_dir%/templates"
- *     file_name_pattern?: list<scalar|null|Param>,
+ *     default_path?: scalar|Param|null, // The default path used to load templates. // Default: "%kernel.project_dir%/templates"
+ *     file_name_pattern?: string|list<scalar|Param|null>,
  *     paths?: array<string, mixed>,
  *     date?: array{ // The default format options used by the date filter.
- *         format?: scalar|null|Param, // Default: "F j, Y H:i"
- *         interval_format?: scalar|null|Param, // Default: "%d days"
- *         timezone?: scalar|null|Param, // The timezone used when formatting dates, when set to null, the timezone returned by date_default_timezone_get() is used. // Default: null
+ *         format?: scalar|Param|null, // Default: "F j, Y H:i"
+ *         interval_format?: scalar|Param|null, // Default: "%d days"
+ *         timezone?: scalar|Param|null, // The timezone used when formatting dates, when set to null, the timezone returned by date_default_timezone_get() is used. // Default: null
  *     },
  *     number_format?: array{ // The default format options for the number_format filter.
  *         decimals?: int|Param, // Default: 0
- *         decimal_point?: scalar|null|Param, // Default: "."
- *         thousands_separator?: scalar|null|Param, // Default: ","
+ *         decimal_point?: scalar|Param|null, // Default: "."
+ *         thousands_separator?: scalar|Param|null, // Default: ","
  *     },
  *     mailer?: array{
- *         html_to_text_converter?: scalar|null|Param, // A service implementing the "Symfony\Component\Mime\HtmlToTextConverter\HtmlToTextConverterInterface". // Default: null
+ *         html_to_text_converter?: scalar|Param|null, // A service implementing the "Symfony\Component\Mime\HtmlToTextConverter\HtmlToTextConverterInterface". // Default: null
  *     },
  * }
  * @psalm-type WebProfilerConfig = array{
@@ -872,102 +882,102 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         ajax_replace?: bool|Param, // Replace toolbar on AJAX requests // Default: false
  *     },
  *     intercept_redirects?: bool|Param, // Default: false
- *     excluded_ajax_paths?: scalar|null|Param, // Default: "^/((index|app(_[\\w]+)?)\\.php/)?_wdt"
+ *     excluded_ajax_paths?: scalar|Param|null, // Default: "^/((index|app(_[\\w]+)?)\\.php/)?_wdt"
  * }
  * @psalm-type DebugConfig = array{
  *     max_items?: int|Param, // Max number of displayed items past the first level, -1 means no limit. // Default: 2500
  *     min_depth?: int|Param, // Minimum tree depth to clone all the items, 1 is default. // Default: 1
  *     max_string_length?: int|Param, // Max length of displayed strings, -1 means no limit. // Default: -1
- *     dump_destination?: scalar|null|Param, // A stream URL where dumps should be written to. // Default: null
+ *     dump_destination?: scalar|Param|null, // A stream URL where dumps should be written to. // Default: null
  *     theme?: "dark"|"light"|Param, // Changes the color of the dump() output when rendered directly on the templating. "dark" (default) or "light". // Default: "dark"
  * }
  * @psalm-type DoctrineConfig = array{
  *     dbal?: array{
- *         default_connection?: scalar|null|Param,
+ *         default_connection?: scalar|Param|null,
  *         types?: array<string, string|array{ // Default: []
- *             class: scalar|null|Param,
+ *             class?: scalar|Param|null,
  *         }>,
- *         driver_schemes?: array<string, scalar|null|Param>,
+ *         driver_schemes?: array<string, scalar|Param|null>,
  *         connections?: array<string, array{ // Default: []
- *             url?: scalar|null|Param, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *             dbname?: scalar|null|Param,
- *             host?: scalar|null|Param, // Defaults to "localhost" at runtime.
- *             port?: scalar|null|Param, // Defaults to null at runtime.
- *             user?: scalar|null|Param, // Defaults to "root" at runtime.
- *             password?: scalar|null|Param, // Defaults to null at runtime.
- *             dbname_suffix?: scalar|null|Param, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *             application_name?: scalar|null|Param,
- *             charset?: scalar|null|Param,
- *             path?: scalar|null|Param,
+ *             url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *             dbname?: scalar|Param|null,
+ *             host?: scalar|Param|null, // Defaults to "localhost" at runtime.
+ *             port?: scalar|Param|null, // Defaults to null at runtime.
+ *             user?: scalar|Param|null, // Defaults to "root" at runtime.
+ *             password?: scalar|Param|null, // Defaults to null at runtime.
+ *             dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *             application_name?: scalar|Param|null,
+ *             charset?: scalar|Param|null,
+ *             path?: scalar|Param|null,
  *             memory?: bool|Param,
- *             unix_socket?: scalar|null|Param, // The unix socket to use for MySQL
+ *             unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
  *             persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
- *             protocol?: scalar|null|Param, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *             protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
  *             service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *             servicename?: scalar|null|Param, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *             sessionMode?: scalar|null|Param, // The session mode to use for the oci8 driver
- *             server?: scalar|null|Param, // The name of a running database server to connect to for SQL Anywhere.
- *             default_dbname?: scalar|null|Param, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *             sslmode?: scalar|null|Param, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *             sslrootcert?: scalar|null|Param, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *             sslcert?: scalar|null|Param, // The path to the SSL client certificate file for PostgreSQL.
- *             sslkey?: scalar|null|Param, // The path to the SSL client key file for PostgreSQL.
- *             sslcrl?: scalar|null|Param, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *             servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *             sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
+ *             server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
+ *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
+ *             sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *             sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *             sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
+ *             sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
+ *             sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
  *             pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
  *             MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *             instancename?: scalar|null|Param, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *             connectstring?: scalar|null|Param, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
- *             driver?: scalar|null|Param, // Default: "pdo_mysql"
+ *             instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *             connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *             driver?: scalar|Param|null, // Default: "pdo_mysql"
  *             auto_commit?: bool|Param,
- *             schema_filter?: scalar|null|Param,
+ *             schema_filter?: scalar|Param|null,
  *             logging?: bool|Param, // Default: true
  *             profiling?: bool|Param, // Default: true
  *             profiling_collect_backtrace?: bool|Param, // Enables collecting backtraces when profiling is enabled // Default: false
  *             profiling_collect_schema_errors?: bool|Param, // Enables collecting schema errors when profiling is enabled // Default: true
- *             server_version?: scalar|null|Param,
+ *             server_version?: scalar|Param|null,
  *             idle_connection_ttl?: int|Param, // Default: 600
- *             driver_class?: scalar|null|Param,
- *             wrapper_class?: scalar|null|Param,
+ *             driver_class?: scalar|Param|null,
+ *             wrapper_class?: scalar|Param|null,
  *             keep_replica?: bool|Param,
  *             options?: array<string, mixed>,
- *             mapping_types?: array<string, scalar|null|Param>,
- *             default_table_options?: array<string, scalar|null|Param>,
- *             schema_manager_factory?: scalar|null|Param, // Default: "doctrine.dbal.default_schema_manager_factory"
- *             result_cache?: scalar|null|Param,
+ *             mapping_types?: array<string, scalar|Param|null>,
+ *             default_table_options?: array<string, scalar|Param|null>,
+ *             schema_manager_factory?: scalar|Param|null, // Default: "doctrine.dbal.default_schema_manager_factory"
+ *             result_cache?: scalar|Param|null,
  *             replicas?: array<string, array{ // Default: []
- *                 url?: scalar|null|Param, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
- *                 dbname?: scalar|null|Param,
- *                 host?: scalar|null|Param, // Defaults to "localhost" at runtime.
- *                 port?: scalar|null|Param, // Defaults to null at runtime.
- *                 user?: scalar|null|Param, // Defaults to "root" at runtime.
- *                 password?: scalar|null|Param, // Defaults to null at runtime.
- *                 dbname_suffix?: scalar|null|Param, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
- *                 application_name?: scalar|null|Param,
- *                 charset?: scalar|null|Param,
- *                 path?: scalar|null|Param,
+ *                 url?: scalar|Param|null, // A URL with connection information; any parameter value parsed from this string will override explicitly set parameters
+ *                 dbname?: scalar|Param|null,
+ *                 host?: scalar|Param|null, // Defaults to "localhost" at runtime.
+ *                 port?: scalar|Param|null, // Defaults to null at runtime.
+ *                 user?: scalar|Param|null, // Defaults to "root" at runtime.
+ *                 password?: scalar|Param|null, // Defaults to null at runtime.
+ *                 dbname_suffix?: scalar|Param|null, // Adds the given suffix to the configured database name, this option has no effects for the SQLite platform
+ *                 application_name?: scalar|Param|null,
+ *                 charset?: scalar|Param|null,
+ *                 path?: scalar|Param|null,
  *                 memory?: bool|Param,
- *                 unix_socket?: scalar|null|Param, // The unix socket to use for MySQL
+ *                 unix_socket?: scalar|Param|null, // The unix socket to use for MySQL
  *                 persistent?: bool|Param, // True to use as persistent connection for the ibm_db2 driver
- *                 protocol?: scalar|null|Param, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
+ *                 protocol?: scalar|Param|null, // The protocol to use for the ibm_db2 driver (default to TCPIP if omitted)
  *                 service?: bool|Param, // True to use SERVICE_NAME as connection parameter instead of SID for Oracle
- *                 servicename?: scalar|null|Param, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
- *                 sessionMode?: scalar|null|Param, // The session mode to use for the oci8 driver
- *                 server?: scalar|null|Param, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|null|Param, // Override the default database (postgres) to connect to for PostgreSQL connexion.
- *                 sslmode?: scalar|null|Param, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
- *                 sslrootcert?: scalar|null|Param, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
- *                 sslcert?: scalar|null|Param, // The path to the SSL client certificate file for PostgreSQL.
- *                 sslkey?: scalar|null|Param, // The path to the SSL client key file for PostgreSQL.
- *                 sslcrl?: scalar|null|Param, // The file name of the SSL certificate revocation list for PostgreSQL.
+ *                 servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
+ *                 sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
+ *                 server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
+ *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
+ *                 sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
+ *                 sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+ *                 sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
+ *                 sslkey?: scalar|Param|null, // The path to the SSL client key file for PostgreSQL.
+ *                 sslcrl?: scalar|Param|null, // The file name of the SSL certificate revocation list for PostgreSQL.
  *                 pooled?: bool|Param, // True to use a pooled server with the oci8/pdo_oracle driver
  *                 MultipleActiveResultSets?: bool|Param, // Configuring MultipleActiveResultSets for the pdo_sqlsrv driver
- *                 instancename?: scalar|null|Param, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
- *                 connectstring?: scalar|null|Param, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
+ *                 instancename?: scalar|Param|null, // Optional parameter, complete whether to add the INSTANCE_NAME parameter in the connection. It is generally used to connect to an Oracle RAC server to select the name of a particular instance.
+ *                 connectstring?: scalar|Param|null, // Complete Easy Connect connection descriptor, see https://docs.oracle.com/database/121/NETAG/naming.htm.When using this option, you will still need to provide the user and password parameters, but the other parameters will no longer be used. Note that when using this parameter, the getHost and getPort methods from Doctrine\DBAL\Connection will no longer function as expected.
  *             }>,
  *         }>,
  *     },
  *     orm?: array{
- *         default_entity_manager?: scalar|null|Param,
+ *         default_entity_manager?: scalar|Param|null,
  *         enable_native_lazy_objects?: bool|Param, // Deprecated: The "enable_native_lazy_objects" option is deprecated and will be removed in DoctrineBundle 4.0, as native lazy objects are now always enabled. // Default: true
  *         controller_resolver?: bool|array{
  *             enabled?: bool|Param, // Default: true
@@ -976,476 +986,478 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *         entity_managers?: array<string, array{ // Default: []
  *             query_cache_driver?: string|array{
- *                 type?: scalar|null|Param, // Default: null
- *                 id?: scalar|null|Param,
- *                 pool?: scalar|null|Param,
+ *                 type?: scalar|Param|null, // Default: null
+ *                 id?: scalar|Param|null,
+ *                 pool?: scalar|Param|null,
  *             },
  *             metadata_cache_driver?: string|array{
- *                 type?: scalar|null|Param, // Default: null
- *                 id?: scalar|null|Param,
- *                 pool?: scalar|null|Param,
+ *                 type?: scalar|Param|null, // Default: null
+ *                 id?: scalar|Param|null,
+ *                 pool?: scalar|Param|null,
  *             },
  *             result_cache_driver?: string|array{
- *                 type?: scalar|null|Param, // Default: null
- *                 id?: scalar|null|Param,
- *                 pool?: scalar|null|Param,
+ *                 type?: scalar|Param|null, // Default: null
+ *                 id?: scalar|Param|null,
+ *                 pool?: scalar|Param|null,
  *             },
  *             entity_listeners?: array{
  *                 entities?: array<string, array{ // Default: []
  *                     listeners?: array<string, array{ // Default: []
  *                         events?: list<array{ // Default: []
- *                             type?: scalar|null|Param,
- *                             method?: scalar|null|Param, // Default: null
+ *                             type?: scalar|Param|null,
+ *                             method?: scalar|Param|null, // Default: null
  *                         }>,
  *                     }>,
  *                 }>,
  *             },
- *             connection?: scalar|null|Param,
- *             class_metadata_factory_name?: scalar|null|Param, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
- *             default_repository_class?: scalar|null|Param, // Default: "Doctrine\\ORM\\EntityRepository"
- *             auto_mapping?: scalar|null|Param, // Default: false
- *             naming_strategy?: scalar|null|Param, // Default: "doctrine.orm.naming_strategy.default"
- *             quote_strategy?: scalar|null|Param, // Default: "doctrine.orm.quote_strategy.default"
- *             typed_field_mapper?: scalar|null|Param, // Default: "doctrine.orm.typed_field_mapper.default"
- *             entity_listener_resolver?: scalar|null|Param, // Default: null
- *             fetch_mode_subselect_batch_size?: scalar|null|Param,
- *             repository_factory?: scalar|null|Param, // Default: "doctrine.orm.container_repository_factory"
- *             schema_ignore_classes?: list<scalar|null|Param>,
+ *             connection?: scalar|Param|null,
+ *             class_metadata_factory_name?: scalar|Param|null, // Default: "Doctrine\\ORM\\Mapping\\ClassMetadataFactory"
+ *             default_repository_class?: scalar|Param|null, // Default: "Doctrine\\ORM\\EntityRepository"
+ *             auto_mapping?: scalar|Param|null, // Default: false
+ *             naming_strategy?: scalar|Param|null, // Default: "doctrine.orm.naming_strategy.default"
+ *             quote_strategy?: scalar|Param|null, // Default: "doctrine.orm.quote_strategy.default"
+ *             typed_field_mapper?: scalar|Param|null, // Default: "doctrine.orm.typed_field_mapper.default"
+ *             entity_listener_resolver?: scalar|Param|null, // Default: null
+ *             fetch_mode_subselect_batch_size?: scalar|Param|null,
+ *             repository_factory?: scalar|Param|null, // Default: "doctrine.orm.container_repository_factory"
+ *             schema_ignore_classes?: list<scalar|Param|null>,
  *             validate_xml_mapping?: bool|Param, // Set to "true" to opt-in to the new mapping driver mode that was added in Doctrine ORM 2.14 and will be mandatory in ORM 3.0. See https://github.com/doctrine/orm/pull/6728. // Default: false
  *             second_level_cache?: array{
  *                 region_cache_driver?: string|array{
- *                     type?: scalar|null|Param, // Default: null
- *                     id?: scalar|null|Param,
- *                     pool?: scalar|null|Param,
+ *                     type?: scalar|Param|null, // Default: null
+ *                     id?: scalar|Param|null,
+ *                     pool?: scalar|Param|null,
  *                 },
- *                 region_lock_lifetime?: scalar|null|Param, // Default: 60
+ *                 region_lock_lifetime?: scalar|Param|null, // Default: 60
  *                 log_enabled?: bool|Param, // Default: true
- *                 region_lifetime?: scalar|null|Param, // Default: 3600
+ *                 region_lifetime?: scalar|Param|null, // Default: 3600
  *                 enabled?: bool|Param, // Default: true
- *                 factory?: scalar|null|Param,
+ *                 factory?: scalar|Param|null,
  *                 regions?: array<string, array{ // Default: []
  *                     cache_driver?: string|array{
- *                         type?: scalar|null|Param, // Default: null
- *                         id?: scalar|null|Param,
- *                         pool?: scalar|null|Param,
+ *                         type?: scalar|Param|null, // Default: null
+ *                         id?: scalar|Param|null,
+ *                         pool?: scalar|Param|null,
  *                     },
- *                     lock_path?: scalar|null|Param, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
- *                     lock_lifetime?: scalar|null|Param, // Default: 60
- *                     type?: scalar|null|Param, // Default: "default"
- *                     lifetime?: scalar|null|Param, // Default: 0
- *                     service?: scalar|null|Param,
- *                     name?: scalar|null|Param,
+ *                     lock_path?: scalar|Param|null, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
+ *                     lock_lifetime?: scalar|Param|null, // Default: 60
+ *                     type?: scalar|Param|null, // Default: "default"
+ *                     lifetime?: scalar|Param|null, // Default: null
+ *                     service?: scalar|Param|null,
+ *                     name?: scalar|Param|null,
  *                 }>,
  *                 loggers?: array<string, array{ // Default: []
- *                     name?: scalar|null|Param,
- *                     service?: scalar|null|Param,
+ *                     name?: scalar|Param|null,
+ *                     service?: scalar|Param|null,
  *                 }>,
  *             },
- *             hydrators?: array<string, scalar|null|Param>,
+ *             hydrators?: array<string, scalar|Param|null>,
  *             mappings?: array<string, bool|string|array{ // Default: []
- *                 mapping?: scalar|null|Param, // Default: true
- *                 type?: scalar|null|Param,
- *                 dir?: scalar|null|Param,
- *                 alias?: scalar|null|Param,
- *                 prefix?: scalar|null|Param,
+ *                 mapping?: scalar|Param|null, // Default: true
+ *                 type?: scalar|Param|null,
+ *                 dir?: scalar|Param|null,
+ *                 alias?: scalar|Param|null,
+ *                 prefix?: scalar|Param|null,
  *                 is_bundle?: bool|Param,
  *             }>,
  *             dql?: array{
- *                 string_functions?: array<string, scalar|null|Param>,
- *                 numeric_functions?: array<string, scalar|null|Param>,
- *                 datetime_functions?: array<string, scalar|null|Param>,
+ *                 string_functions?: array<string, scalar|Param|null>,
+ *                 numeric_functions?: array<string, scalar|Param|null>,
+ *                 datetime_functions?: array<string, scalar|Param|null>,
  *             },
  *             filters?: array<string, string|array{ // Default: []
- *                 class: scalar|null|Param,
+ *                 class?: scalar|Param|null,
  *                 enabled?: bool|Param, // Default: false
  *                 parameters?: array<string, mixed>,
  *             }>,
- *             identity_generation_preferences?: array<string, scalar|null|Param>,
+ *             identity_generation_preferences?: array<string, scalar|Param|null>,
  *         }>,
- *         resolve_target_entities?: array<string, scalar|null|Param>,
+ *         resolve_target_entities?: array<string, scalar|Param|null>,
  *     },
  * }
  * @psalm-type DoctrineMigrationsConfig = array{
  *     enable_service_migrations?: bool|Param, // Whether to enable fetching migrations from the service container. // Default: false
- *     migrations_paths?: array<string, scalar|null|Param>,
- *     services?: array<string, scalar|null|Param>,
- *     factories?: array<string, scalar|null|Param>,
+ *     migrations_paths?: array<string, scalar|Param|null>,
+ *     services?: array<string, scalar|Param|null>,
+ *     factories?: array<string, scalar|Param|null>,
  *     storage?: array{ // Storage to use for migration status metadata.
  *         table_storage?: array{ // The default metadata storage, implemented as a table in the database.
- *             table_name?: scalar|null|Param, // Default: null
- *             version_column_name?: scalar|null|Param, // Default: null
- *             version_column_length?: scalar|null|Param, // Default: null
- *             executed_at_column_name?: scalar|null|Param, // Default: null
- *             execution_time_column_name?: scalar|null|Param, // Default: null
+ *             table_name?: scalar|Param|null, // Default: null
+ *             version_column_name?: scalar|Param|null, // Default: null
+ *             version_column_length?: scalar|Param|null, // Default: null
+ *             executed_at_column_name?: scalar|Param|null, // Default: null
+ *             execution_time_column_name?: scalar|Param|null, // Default: null
  *         },
  *     },
- *     migrations?: list<scalar|null|Param>,
- *     connection?: scalar|null|Param, // Connection name to use for the migrations database. // Default: null
- *     em?: scalar|null|Param, // Entity manager name to use for the migrations database (available when doctrine/orm is installed). // Default: null
- *     all_or_nothing?: scalar|null|Param, // Run all migrations in a transaction. // Default: false
- *     check_database_platform?: scalar|null|Param, // Adds an extra check in the generated migrations to allow execution only on the same platform as they were initially generated on. // Default: true
- *     custom_template?: scalar|null|Param, // Custom template path for generated migration classes. // Default: null
- *     organize_migrations?: scalar|null|Param, // Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false // Default: false
+ *     migrations?: list<scalar|Param|null>,
+ *     connection?: scalar|Param|null, // Connection name to use for the migrations database. // Default: null
+ *     em?: scalar|Param|null, // Entity manager name to use for the migrations database (available when doctrine/orm is installed). // Default: null
+ *     all_or_nothing?: scalar|Param|null, // Run all migrations in a transaction. // Default: false
+ *     check_database_platform?: scalar|Param|null, // Adds an extra check in the generated migrations to allow execution only on the same platform as they were initially generated on. // Default: true
+ *     custom_template?: scalar|Param|null, // Custom template path for generated migration classes. // Default: null
+ *     organize_migrations?: scalar|Param|null, // Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false // Default: false
  *     enable_profiler?: bool|Param, // Whether or not to enable the profiler collector to calculate and visualize migration status. This adds some queries overhead. // Default: false
  *     transactional?: bool|Param, // Whether or not to wrap migrations in a single transaction. // Default: true
  * }
  * @psalm-type MakerConfig = array{
- *     root_namespace?: scalar|null|Param, // Default: "App"
+ *     root_namespace?: scalar|Param|null, // Default: "App"
  *     generate_final_classes?: bool|Param, // Default: true
  *     generate_final_entities?: bool|Param, // Default: false
  * }
  * @psalm-type SecurityConfig = array{
- *     access_denied_url?: scalar|null|Param, // Default: null
+ *     access_denied_url?: scalar|Param|null, // Default: null
  *     session_fixation_strategy?: "none"|"migrate"|"invalidate"|Param, // Default: "migrate"
- *     hide_user_not_found?: bool|Param, // Deprecated: The "hide_user_not_found" option is deprecated and will be removed in 8.0. Use the "expose_security_errors" option instead.
  *     expose_security_errors?: \Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::None|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::AccountStatus|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::All|Param, // Default: "none"
- *     erase_credentials?: bool|Param, // Default: true
+ *     erase_credentials?: bool|Param, // Deprecated: Setting the "security.erase_credentials.erase_credentials" configuration option is deprecated. It will be removed in Symfony 9.0, as the "eraseCredentials()" method was removed in Symfony 8.0. // Default: true
  *     access_decision_manager?: array{
  *         strategy?: "affirmative"|"consensus"|"unanimous"|"priority"|Param,
- *         service?: scalar|null|Param,
- *         strategy_service?: scalar|null|Param,
+ *         service?: scalar|Param|null,
+ *         strategy_service?: scalar|Param|null,
  *         allow_if_all_abstain?: bool|Param, // Default: false
  *         allow_if_equal_granted_denied?: bool|Param, // Default: true
  *     },
  *     password_hashers?: array<string, string|array{ // Default: []
- *         algorithm?: scalar|null|Param,
- *         migrate_from?: list<scalar|null|Param>,
- *         hash_algorithm?: scalar|null|Param, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
- *         key_length?: scalar|null|Param, // Default: 40
+ *         algorithm?: scalar|Param|null,
+ *         migrate_from?: string|list<scalar|Param|null>,
+ *         hash_algorithm?: scalar|Param|null, // Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms. // Default: "sha512"
+ *         key_length?: scalar|Param|null, // Default: 40
  *         ignore_case?: bool|Param, // Default: false
  *         encode_as_base64?: bool|Param, // Default: true
- *         iterations?: scalar|null|Param, // Default: 5000
+ *         iterations?: scalar|Param|null, // Default: 5000
  *         cost?: int|Param, // Default: null
- *         memory_cost?: scalar|null|Param, // Default: null
- *         time_cost?: scalar|null|Param, // Default: null
- *         id?: scalar|null|Param,
+ *         memory_cost?: scalar|Param|null, // Default: null
+ *         time_cost?: scalar|Param|null, // Default: null
+ *         id?: scalar|Param|null,
  *     }>,
  *     providers?: array<string, array{ // Default: []
- *         id?: scalar|null|Param,
+ *         id?: scalar|Param|null,
  *         chain?: array{
- *             providers?: list<scalar|null|Param>,
+ *             providers?: string|list<scalar|Param|null>,
  *         },
  *         entity?: array{
- *             class: scalar|null|Param, // The full entity class name of your user class.
- *             property?: scalar|null|Param, // Default: null
- *             manager_name?: scalar|null|Param, // Default: null
+ *             class?: scalar|Param|null, // The full entity class name of your user class.
+ *             property?: scalar|Param|null, // Default: null
+ *             manager_name?: scalar|Param|null, // Default: null
  *         },
  *         memory?: array{
  *             users?: array<string, array{ // Default: []
- *                 password?: scalar|null|Param, // Default: null
- *                 roles?: list<scalar|null|Param>,
+ *                 password?: scalar|Param|null, // Default: null
+ *                 roles?: string|list<scalar|Param|null>,
  *             }>,
  *         },
  *         ldap?: array{
- *             service: scalar|null|Param,
- *             base_dn: scalar|null|Param,
- *             search_dn?: scalar|null|Param, // Default: null
- *             search_password?: scalar|null|Param, // Default: null
- *             extra_fields?: list<scalar|null|Param>,
- *             default_roles?: list<scalar|null|Param>,
- *             role_fetcher?: scalar|null|Param, // Default: null
- *             uid_key?: scalar|null|Param, // Default: "sAMAccountName"
- *             filter?: scalar|null|Param, // Default: "({uid_key}={user_identifier})"
- *             password_attribute?: scalar|null|Param, // Default: null
+ *             service?: scalar|Param|null,
+ *             base_dn?: scalar|Param|null,
+ *             search_dn?: scalar|Param|null, // Default: null
+ *             search_password?: scalar|Param|null, // Default: null
+ *             extra_fields?: list<scalar|Param|null>,
+ *             default_roles?: string|list<scalar|Param|null>,
+ *             role_fetcher?: scalar|Param|null, // Default: null
+ *             uid_key?: scalar|Param|null, // Default: "sAMAccountName"
+ *             filter?: scalar|Param|null, // Default: "({uid_key}={user_identifier})"
+ *             password_attribute?: scalar|Param|null, // Default: null
  *         },
  *     }>,
- *     firewalls: array<string, array{ // Default: []
- *         pattern?: scalar|null|Param,
- *         host?: scalar|null|Param,
- *         methods?: list<scalar|null|Param>,
+ *     firewalls?: array<string, array{ // Default: []
+ *         pattern?: scalar|Param|null,
+ *         host?: scalar|Param|null,
+ *         methods?: string|list<scalar|Param|null>,
  *         security?: bool|Param, // Default: true
- *         user_checker?: scalar|null|Param, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
- *         request_matcher?: scalar|null|Param,
- *         access_denied_url?: scalar|null|Param,
- *         access_denied_handler?: scalar|null|Param,
- *         entry_point?: scalar|null|Param, // An enabled authenticator name or a service id that implements "Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface".
- *         provider?: scalar|null|Param,
+ *         user_checker?: scalar|Param|null, // The UserChecker to use when authenticating users in this firewall. // Default: "security.user_checker"
+ *         request_matcher?: scalar|Param|null,
+ *         access_denied_url?: scalar|Param|null,
+ *         access_denied_handler?: scalar|Param|null,
+ *         entry_point?: scalar|Param|null, // An enabled authenticator name or a service id that implements "Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface".
+ *         provider?: scalar|Param|null,
  *         stateless?: bool|Param, // Default: false
  *         lazy?: bool|Param, // Default: false
- *         context?: scalar|null|Param,
+ *         context?: scalar|Param|null,
  *         logout?: array{
- *             enable_csrf?: bool|null|Param, // Default: null
- *             csrf_token_id?: scalar|null|Param, // Default: "logout"
- *             csrf_parameter?: scalar|null|Param, // Default: "_csrf_token"
- *             csrf_token_manager?: scalar|null|Param,
- *             path?: scalar|null|Param, // Default: "/logout"
- *             target?: scalar|null|Param, // Default: "/"
+ *             enable_csrf?: bool|Param|null, // Default: null
+ *             csrf_token_id?: scalar|Param|null, // Default: "logout"
+ *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *             csrf_token_manager?: scalar|Param|null,
+ *             path?: scalar|Param|null, // Default: "/logout"
+ *             target?: scalar|Param|null, // Default: "/"
  *             invalidate_session?: bool|Param, // Default: true
- *             clear_site_data?: list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
- *             delete_cookies?: array<string, array{ // Default: []
- *                 path?: scalar|null|Param, // Default: null
- *                 domain?: scalar|null|Param, // Default: null
- *                 secure?: scalar|null|Param, // Default: false
- *                 samesite?: scalar|null|Param, // Default: null
- *                 partitioned?: scalar|null|Param, // Default: false
+ *             clear_site_data?: string|list<"*"|"cache"|"cookies"|"storage"|"clientHints"|"executionContexts"|"prefetchCache"|"prerenderCache"|Param>,
+ *             delete_cookies?: string|array<string, array{ // Default: []
+ *                 path?: scalar|Param|null, // Default: null
+ *                 domain?: scalar|Param|null, // Default: null
+ *                 secure?: scalar|Param|null, // Default: false
+ *                 samesite?: scalar|Param|null, // Default: null
+ *                 partitioned?: scalar|Param|null, // Default: false
  *             }>,
  *         },
  *         switch_user?: array{
- *             provider?: scalar|null|Param,
- *             parameter?: scalar|null|Param, // Default: "_switch_user"
- *             role?: scalar|null|Param, // Default: "ROLE_ALLOWED_TO_SWITCH"
- *             target_route?: scalar|null|Param, // Default: null
+ *             provider?: scalar|Param|null,
+ *             parameter?: scalar|Param|null, // Default: "_switch_user"
+ *             role?: scalar|Param|null, // Default: "ROLE_ALLOWED_TO_SWITCH"
+ *             target_route?: scalar|Param|null, // Default: null
  *         },
- *         required_badges?: list<scalar|null|Param>,
- *         custom_authenticators?: list<scalar|null|Param>,
+ *         required_badges?: list<scalar|Param|null>,
+ *         custom_authenticators?: list<scalar|Param|null>,
  *         login_throttling?: array{
- *             limiter?: scalar|null|Param, // A service id implementing "Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface".
+ *             limiter?: scalar|Param|null, // A service id implementing "Symfony\Component\HttpFoundation\RateLimiter\RequestRateLimiterInterface".
  *             max_attempts?: int|Param, // Default: 5
- *             interval?: scalar|null|Param, // Default: "1 minute"
- *             lock_factory?: scalar|null|Param, // The service ID of the lock factory used by the login rate limiter (or null to disable locking). // Default: null
+ *             interval?: scalar|Param|null, // Default: "1 minute"
+ *             lock_factory?: scalar|Param|null, // The service ID of the lock factory used by the login rate limiter (or null to disable locking). // Default: null
  *             cache_pool?: string|Param, // The cache pool to use for storing the limiter state // Default: "cache.rate_limiter"
  *             storage_service?: string|Param, // The service ID of a custom storage implementation, this precedes any configured "cache_pool" // Default: null
  *         },
  *         x509?: array{
- *             provider?: scalar|null|Param,
- *             user?: scalar|null|Param, // Default: "SSL_CLIENT_S_DN_Email"
- *             credentials?: scalar|null|Param, // Default: "SSL_CLIENT_S_DN"
- *             user_identifier?: scalar|null|Param, // Default: "emailAddress"
+ *             provider?: scalar|Param|null,
+ *             user?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN_Email"
+ *             credentials?: scalar|Param|null, // Default: "SSL_CLIENT_S_DN"
+ *             user_identifier?: scalar|Param|null, // Default: "emailAddress"
  *         },
  *         remote_user?: array{
- *             provider?: scalar|null|Param,
- *             user?: scalar|null|Param, // Default: "REMOTE_USER"
+ *             provider?: scalar|Param|null,
+ *             user?: scalar|Param|null, // Default: "REMOTE_USER"
  *         },
  *         login_link?: array{
- *             check_route: scalar|null|Param, // Route that will validate the login link - e.g. "app_login_link_verify".
- *             check_post_only?: scalar|null|Param, // If true, only HTTP POST requests to "check_route" will be handled by the authenticator. // Default: false
- *             signature_properties: list<scalar|null|Param>,
+ *             check_route?: scalar|Param|null, // Route that will validate the login link - e.g. "app_login_link_verify".
+ *             check_post_only?: scalar|Param|null, // If true, only HTTP POST requests to "check_route" will be handled by the authenticator. // Default: false
+ *             signature_properties?: list<scalar|Param|null>,
  *             lifetime?: int|Param, // The lifetime of the login link in seconds. // Default: 600
  *             max_uses?: int|Param, // Max number of times a login link can be used - null means unlimited within lifetime. // Default: null
- *             used_link_cache?: scalar|null|Param, // Cache service id used to expired links of max_uses is set.
- *             success_handler?: scalar|null|Param, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface.
- *             failure_handler?: scalar|null|Param, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface.
- *             provider?: scalar|null|Param, // The user provider to load users from.
- *             secret?: scalar|null|Param, // Default: "%kernel.secret%"
+ *             used_link_cache?: scalar|Param|null, // Cache service id used to expired links of max_uses is set.
+ *             success_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface.
+ *             failure_handler?: scalar|Param|null, // A service id that implements Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface.
+ *             provider?: scalar|Param|null, // The user provider to load users from.
+ *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
  *             always_use_default_target_path?: bool|Param, // Default: false
- *             default_target_path?: scalar|null|Param, // Default: "/"
- *             login_path?: scalar|null|Param, // Default: "/login"
- *             target_path_parameter?: scalar|null|Param, // Default: "_target_path"
+ *             default_target_path?: scalar|Param|null, // Default: "/"
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
  *             use_referer?: bool|Param, // Default: false
- *             failure_path?: scalar|null|Param, // Default: null
+ *             failure_path?: scalar|Param|null, // Default: null
  *             failure_forward?: bool|Param, // Default: false
- *             failure_path_parameter?: scalar|null|Param, // Default: "_failure_path"
+ *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
  *         },
  *         form_login?: array{
- *             provider?: scalar|null|Param,
+ *             provider?: scalar|Param|null,
  *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|null|Param,
- *             failure_handler?: scalar|null|Param,
- *             check_path?: scalar|null|Param, // Default: "/login_check"
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             check_path?: scalar|Param|null, // Default: "/login_check"
  *             use_forward?: bool|Param, // Default: false
- *             login_path?: scalar|null|Param, // Default: "/login"
- *             username_parameter?: scalar|null|Param, // Default: "_username"
- *             password_parameter?: scalar|null|Param, // Default: "_password"
- *             csrf_parameter?: scalar|null|Param, // Default: "_csrf_token"
- *             csrf_token_id?: scalar|null|Param, // Default: "authenticate"
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             username_parameter?: scalar|Param|null, // Default: "_username"
+ *             password_parameter?: scalar|Param|null, // Default: "_password"
+ *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *             csrf_token_id?: scalar|Param|null, // Default: "authenticate"
  *             enable_csrf?: bool|Param, // Default: false
  *             post_only?: bool|Param, // Default: true
  *             form_only?: bool|Param, // Default: false
  *             always_use_default_target_path?: bool|Param, // Default: false
- *             default_target_path?: scalar|null|Param, // Default: "/"
- *             target_path_parameter?: scalar|null|Param, // Default: "_target_path"
+ *             default_target_path?: scalar|Param|null, // Default: "/"
+ *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
  *             use_referer?: bool|Param, // Default: false
- *             failure_path?: scalar|null|Param, // Default: null
+ *             failure_path?: scalar|Param|null, // Default: null
  *             failure_forward?: bool|Param, // Default: false
- *             failure_path_parameter?: scalar|null|Param, // Default: "_failure_path"
+ *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
  *         },
  *         form_login_ldap?: array{
- *             provider?: scalar|null|Param,
+ *             provider?: scalar|Param|null,
  *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|null|Param,
- *             failure_handler?: scalar|null|Param,
- *             check_path?: scalar|null|Param, // Default: "/login_check"
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             check_path?: scalar|Param|null, // Default: "/login_check"
  *             use_forward?: bool|Param, // Default: false
- *             login_path?: scalar|null|Param, // Default: "/login"
- *             username_parameter?: scalar|null|Param, // Default: "_username"
- *             password_parameter?: scalar|null|Param, // Default: "_password"
- *             csrf_parameter?: scalar|null|Param, // Default: "_csrf_token"
- *             csrf_token_id?: scalar|null|Param, // Default: "authenticate"
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             username_parameter?: scalar|Param|null, // Default: "_username"
+ *             password_parameter?: scalar|Param|null, // Default: "_password"
+ *             csrf_parameter?: scalar|Param|null, // Default: "_csrf_token"
+ *             csrf_token_id?: scalar|Param|null, // Default: "authenticate"
  *             enable_csrf?: bool|Param, // Default: false
  *             post_only?: bool|Param, // Default: true
  *             form_only?: bool|Param, // Default: false
  *             always_use_default_target_path?: bool|Param, // Default: false
- *             default_target_path?: scalar|null|Param, // Default: "/"
- *             target_path_parameter?: scalar|null|Param, // Default: "_target_path"
+ *             default_target_path?: scalar|Param|null, // Default: "/"
+ *             target_path_parameter?: scalar|Param|null, // Default: "_target_path"
  *             use_referer?: bool|Param, // Default: false
- *             failure_path?: scalar|null|Param, // Default: null
+ *             failure_path?: scalar|Param|null, // Default: null
  *             failure_forward?: bool|Param, // Default: false
- *             failure_path_parameter?: scalar|null|Param, // Default: "_failure_path"
- *             service?: scalar|null|Param, // Default: "ldap"
- *             dn_string?: scalar|null|Param, // Default: "{user_identifier}"
- *             query_string?: scalar|null|Param,
- *             search_dn?: scalar|null|Param, // Default: ""
- *             search_password?: scalar|null|Param, // Default: ""
+ *             failure_path_parameter?: scalar|Param|null, // Default: "_failure_path"
+ *             service?: scalar|Param|null, // Default: "ldap"
+ *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *             query_string?: scalar|Param|null,
+ *             search_dn?: scalar|Param|null, // Default: ""
+ *             search_password?: scalar|Param|null, // Default: ""
  *         },
  *         json_login?: array{
- *             provider?: scalar|null|Param,
+ *             provider?: scalar|Param|null,
  *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|null|Param,
- *             failure_handler?: scalar|null|Param,
- *             check_path?: scalar|null|Param, // Default: "/login_check"
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             check_path?: scalar|Param|null, // Default: "/login_check"
  *             use_forward?: bool|Param, // Default: false
- *             login_path?: scalar|null|Param, // Default: "/login"
- *             username_path?: scalar|null|Param, // Default: "username"
- *             password_path?: scalar|null|Param, // Default: "password"
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             username_path?: scalar|Param|null, // Default: "username"
+ *             password_path?: scalar|Param|null, // Default: "password"
  *         },
  *         json_login_ldap?: array{
- *             provider?: scalar|null|Param,
+ *             provider?: scalar|Param|null,
  *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|null|Param,
- *             failure_handler?: scalar|null|Param,
- *             check_path?: scalar|null|Param, // Default: "/login_check"
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             check_path?: scalar|Param|null, // Default: "/login_check"
  *             use_forward?: bool|Param, // Default: false
- *             login_path?: scalar|null|Param, // Default: "/login"
- *             username_path?: scalar|null|Param, // Default: "username"
- *             password_path?: scalar|null|Param, // Default: "password"
- *             service?: scalar|null|Param, // Default: "ldap"
- *             dn_string?: scalar|null|Param, // Default: "{user_identifier}"
- *             query_string?: scalar|null|Param,
- *             search_dn?: scalar|null|Param, // Default: ""
- *             search_password?: scalar|null|Param, // Default: ""
+ *             login_path?: scalar|Param|null, // Default: "/login"
+ *             username_path?: scalar|Param|null, // Default: "username"
+ *             password_path?: scalar|Param|null, // Default: "password"
+ *             service?: scalar|Param|null, // Default: "ldap"
+ *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *             query_string?: scalar|Param|null,
+ *             search_dn?: scalar|Param|null, // Default: ""
+ *             search_password?: scalar|Param|null, // Default: ""
  *         },
  *         access_token?: array{
- *             provider?: scalar|null|Param,
+ *             provider?: scalar|Param|null,
  *             remember_me?: bool|Param, // Default: true
- *             success_handler?: scalar|null|Param,
- *             failure_handler?: scalar|null|Param,
- *             realm?: scalar|null|Param, // Default: null
- *             token_extractors?: list<scalar|null|Param>,
- *             token_handler: string|array{
- *                 id?: scalar|null|Param,
+ *             success_handler?: scalar|Param|null,
+ *             failure_handler?: scalar|Param|null,
+ *             realm?: scalar|Param|null, // Default: null
+ *             token_extractors?: string|list<scalar|Param|null>,
+ *             token_handler?: string|array{
+ *                 id?: scalar|Param|null,
  *                 oidc_user_info?: string|array{
- *                     base_uri: scalar|null|Param, // Base URI of the userinfo endpoint on the OIDC server, or the OIDC server URI to use the discovery (require "discovery" to be configured).
+ *                     base_uri?: scalar|Param|null, // Base URI of the userinfo endpoint on the OIDC server, or the OIDC server URI to use the discovery (require "discovery" to be configured).
  *                     discovery?: array{ // Enable the OIDC discovery.
  *                         cache?: array{
- *                             id: scalar|null|Param, // Cache service id to use to cache the OIDC discovery configuration.
+ *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
  *                         },
  *                     },
- *                     claim?: scalar|null|Param, // Claim which contains the user identifier (e.g. sub, email, etc.). // Default: "sub"
- *                     client?: scalar|null|Param, // HttpClient service id to use to call the OIDC server.
+ *                     claim?: scalar|Param|null, // Claim which contains the user identifier (e.g. sub, email, etc.). // Default: "sub"
+ *                     client?: scalar|Param|null, // HttpClient service id to use to call the OIDC server.
  *                 },
  *                 oidc?: array{
  *                     discovery?: array{ // Enable the OIDC discovery.
- *                         base_uri: list<scalar|null|Param>,
+ *                         base_uri?: string|list<scalar|Param|null>,
  *                         cache?: array{
- *                             id: scalar|null|Param, // Cache service id to use to cache the OIDC discovery configuration.
+ *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
  *                         },
+ *                         enforce_key_usage_verification?: bool|Param, // When enabled (default), only keys explicitly designated for signature (via "use":"sig" or a "key_ops" entry containing "sign"/"verify") are accepted. When disabled, keys without any usage designation are also accepted; keys explicitly restricted to encryption are still rejected. // Default: true
  *                     },
- *                     claim?: scalar|null|Param, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
- *                     audience: scalar|null|Param, // Audience set in the token, for validation purpose.
- *                     issuers: list<scalar|null|Param>,
- *                     algorithm?: array<mixed>,
- *                     algorithms: list<scalar|null|Param>,
- *                     key?: scalar|null|Param, // Deprecated: The "key" option is deprecated and will be removed in 8.0. Use the "keyset" option instead. // JSON-encoded JWK used to sign the token (must contain a "kty" key).
- *                     keyset?: scalar|null|Param, // JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).
+ *                     claim?: scalar|Param|null, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
+ *                     audience?: scalar|Param|null, // Audience set in the token, for validation purpose.
+ *                     issuers?: list<scalar|Param|null>,
+ *                     algorithms?: list<scalar|Param|null>,
+ *                     keyset?: scalar|Param|null, // JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).
  *                     encryption?: bool|array{
  *                         enabled?: bool|Param, // Default: false
  *                         enforce?: bool|Param, // When enabled, the token shall be encrypted. // Default: false
- *                         algorithms: list<scalar|null|Param>,
- *                         keyset: scalar|null|Param, // JSON-encoded JWKSet used to decrypt the token (must contain a list of valid private keys).
+ *                         algorithms?: list<scalar|Param|null>,
+ *                         keyset?: scalar|Param|null, // JSON-encoded JWKSet used to decrypt the token (must contain a list of valid private keys).
  *                     },
  *                 },
  *                 cas?: array{
- *                     validation_url: scalar|null|Param, // CAS server validation URL
- *                     prefix?: scalar|null|Param, // CAS prefix // Default: "cas"
- *                     http_client?: scalar|null|Param, // HTTP Client service // Default: null
+ *                     validation_url?: scalar|Param|null, // CAS server validation URL
+ *                     prefix?: scalar|Param|null, // CAS prefix // Default: "cas"
+ *                     http_client?: scalar|Param|null, // HTTP Client service // Default: null
  *                 },
- *                 oauth2?: scalar|null|Param,
+ *                 oauth2?: scalar|Param|null,
  *             },
  *         },
  *         http_basic?: array{
- *             provider?: scalar|null|Param,
- *             realm?: scalar|null|Param, // Default: "Secured Area"
+ *             provider?: scalar|Param|null,
+ *             realm?: scalar|Param|null, // Default: "Secured Area"
  *         },
  *         http_basic_ldap?: array{
- *             provider?: scalar|null|Param,
- *             realm?: scalar|null|Param, // Default: "Secured Area"
- *             service?: scalar|null|Param, // Default: "ldap"
- *             dn_string?: scalar|null|Param, // Default: "{user_identifier}"
- *             query_string?: scalar|null|Param,
- *             search_dn?: scalar|null|Param, // Default: ""
- *             search_password?: scalar|null|Param, // Default: ""
+ *             provider?: scalar|Param|null,
+ *             realm?: scalar|Param|null, // Default: "Secured Area"
+ *             service?: scalar|Param|null, // Default: "ldap"
+ *             dn_string?: scalar|Param|null, // Default: "{user_identifier}"
+ *             query_string?: scalar|Param|null,
+ *             search_dn?: scalar|Param|null, // Default: ""
+ *             search_password?: scalar|Param|null, // Default: ""
  *         },
  *         remember_me?: array{
- *             secret?: scalar|null|Param, // Default: "%kernel.secret%"
- *             service?: scalar|null|Param,
- *             user_providers?: list<scalar|null|Param>,
+ *             secret?: scalar|Param|null, // Default: "%kernel.secret%"
+ *             service?: scalar|Param|null,
+ *             user_providers?: string|list<scalar|Param|null>,
  *             catch_exceptions?: bool|Param, // Default: true
- *             signature_properties?: list<scalar|null|Param>,
+ *             signature_properties?: list<scalar|Param|null>,
  *             token_provider?: string|array{
- *                 service?: scalar|null|Param, // The service ID of a custom remember-me token provider.
+ *                 service?: scalar|Param|null, // The service ID of a custom remember-me token provider.
  *                 doctrine?: bool|array{
  *                     enabled?: bool|Param, // Default: false
- *                     connection?: scalar|null|Param, // Default: null
+ *                     connection?: scalar|Param|null, // Default: null
  *                 },
  *             },
- *             token_verifier?: scalar|null|Param, // The service ID of a custom rememberme token verifier.
- *             name?: scalar|null|Param, // Default: "REMEMBERME"
+ *             token_verifier?: scalar|Param|null, // The service ID of a custom rememberme token verifier.
+ *             name?: scalar|Param|null, // Default: "REMEMBERME"
  *             lifetime?: int|Param, // Default: 31536000
- *             path?: scalar|null|Param, // Default: "/"
- *             domain?: scalar|null|Param, // Default: null
+ *             path?: scalar|Param|null, // Default: "/"
+ *             domain?: scalar|Param|null, // Default: null
  *             secure?: true|false|"auto"|Param, // Default: false
  *             httponly?: bool|Param, // Default: true
  *             samesite?: null|"lax"|"strict"|"none"|Param, // Default: null
  *             always_remember_me?: bool|Param, // Default: false
- *             remember_me_parameter?: scalar|null|Param, // Default: "_remember_me"
+ *             remember_me_parameter?: scalar|Param|null, // Default: "_remember_me"
  *         },
  *     }>,
  *     access_control?: list<array{ // Default: []
- *         request_matcher?: scalar|null|Param, // Default: null
- *         requires_channel?: scalar|null|Param, // Default: null
- *         path?: scalar|null|Param, // Use the urldecoded format. // Default: null
- *         host?: scalar|null|Param, // Default: null
+ *         request_matcher?: scalar|Param|null, // Default: null
+ *         requires_channel?: scalar|Param|null, // Default: null
+ *         path?: scalar|Param|null, // Use the urldecoded format. // Default: null
+ *         host?: scalar|Param|null, // Default: null
  *         port?: int|Param, // Default: null
- *         ips?: list<scalar|null|Param>,
- *         attributes?: array<string, scalar|null|Param>,
- *         route?: scalar|null|Param, // Default: null
- *         methods?: list<scalar|null|Param>,
- *         allow_if?: scalar|null|Param, // Default: null
- *         roles?: list<scalar|null|Param>,
+ *         ips?: string|list<scalar|Param|null>,
+ *         attributes?: array<string, scalar|Param|null>,
+ *         route?: scalar|Param|null, // Default: null
+ *         methods?: string|list<scalar|Param|null>,
+ *         allow_if?: scalar|Param|null, // Default: null
+ *         roles?: string|list<scalar|Param|null>,
  *     }>,
- *     role_hierarchy?: array<string, string|list<scalar|null|Param>>,
+ *     role_hierarchy?: array<string, string|list<scalar|Param|null>>,
  * }
  * @psalm-type NelmioCorsConfig = array{
  *     defaults?: array{
  *         allow_credentials?: bool|Param, // Default: false
- *         allow_origin?: list<scalar|null|Param>,
- *         allow_headers?: list<scalar|null|Param>,
- *         allow_methods?: list<scalar|null|Param>,
+ *         allow_origin?: list<scalar|Param|null>,
+ *         allow_headers?: list<scalar|Param|null>,
+ *         allow_methods?: list<scalar|Param|null>,
  *         allow_private_network?: bool|Param, // Default: false
- *         expose_headers?: list<scalar|null|Param>,
- *         max_age?: scalar|null|Param, // Default: 0
- *         hosts?: list<scalar|null|Param>,
+ *         expose_headers?: list<scalar|Param|null>,
+ *         max_age?: scalar|Param|null, // Default: 0
+ *         hosts?: list<scalar|Param|null>,
  *         origin_regex?: bool|Param, // Default: false
- *         forced_allow_origin_value?: scalar|null|Param, // Default: null
+ *         forced_allow_origin_value?: scalar|Param|null, // Default: null
  *         skip_same_as_origin?: bool|Param, // Default: true
  *     },
  *     paths?: array<string, array{ // Default: []
  *         allow_credentials?: bool|Param,
- *         allow_origin?: list<scalar|null|Param>,
- *         allow_headers?: list<scalar|null|Param>,
- *         allow_methods?: list<scalar|null|Param>,
+ *         allow_origin?: list<scalar|Param|null>,
+ *         allow_headers?: list<scalar|Param|null>,
+ *         allow_methods?: list<scalar|Param|null>,
  *         allow_private_network?: bool|Param,
- *         expose_headers?: list<scalar|null|Param>,
- *         max_age?: scalar|null|Param, // Default: 0
- *         hosts?: list<scalar|null|Param>,
+ *         expose_headers?: list<scalar|Param|null>,
+ *         max_age?: scalar|Param|null, // Default: 0
+ *         hosts?: list<scalar|Param|null>,
  *         origin_regex?: bool|Param,
- *         forced_allow_origin_value?: scalar|null|Param, // Default: null
+ *         forced_allow_origin_value?: scalar|Param|null, // Default: null
  *         skip_same_as_origin?: bool|Param,
  *     }>,
  * }
  * @psalm-type ApiPlatformConfig = array{
- *     title?: scalar|null|Param, // The title of the API. // Default: ""
- *     description?: scalar|null|Param, // The description of the API. // Default: ""
- *     version?: scalar|null|Param, // The version of the API. // Default: "0.0.0"
+ *     title?: scalar|Param|null, // The title of the API. // Default: ""
+ *     description?: scalar|Param|null, // The description of the API. // Default: ""
+ *     version?: scalar|Param|null, // The version of the API. // Default: "0.0.0"
  *     show_webby?: bool|Param, // If true, show Webby on the documentation page // Default: true
  *     use_symfony_listeners?: bool|Param, // Uses Symfony event listeners instead of the ApiPlatform\Symfony\Controller\MainController. // Default: false
- *     name_converter?: scalar|null|Param, // Specify a name converter to use. // Default: null
- *     asset_package?: scalar|null|Param, // Specify an asset package name to use. // Default: null
- *     path_segment_name_generator?: scalar|null|Param, // Specify a path name generator to use. // Default: "api_platform.metadata.path_segment_name_generator.underscore"
- *     inflector?: scalar|null|Param, // Specify an inflector to use. // Default: "api_platform.metadata.inflector"
+ *     name_converter?: scalar|Param|null, // Specify a name converter to use. // Default: null
+ *     asset_package?: scalar|Param|null, // Specify an asset package name to use. // Default: null
+ *     path_segment_name_generator?: scalar|Param|null, // Specify a path name generator to use. // Default: "api_platform.metadata.path_segment_name_generator.underscore"
+ *     inflector?: scalar|Param|null, // Specify an inflector to use. // Default: "api_platform.metadata.inflector"
  *     validator?: array{
  *         serialize_payload_fields?: mixed, // Set to null to serialize all payload fields when a validation error is thrown, or set the fields you want to include explicitly. // Default: []
  *         query_parameter_validation?: bool|Param, // Deprecated: Will be removed in API Platform 5.0. // Default: true
+ *     },
+ *     jsonapi?: array{
+ *         use_iri_as_id?: bool|Param, // Set to false to use entity identifiers instead of IRIs as the "id" field in JSON:API responses. // Default: true
+ *         allow_client_generated_id?: bool|Param, // Allow client-generated IDs on JSON:API POST per https://jsonapi.org/format/#crud-creating-client-ids. Off by default to prevent id spoofing on public endpoints. // Default: false
  *     },
  *     eager_loading?: bool|array{
  *         enabled?: bool|Param, // Default: true
@@ -1458,29 +1470,30 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     enable_json_streamer?: bool|Param, // Enable json streamer. // Default: false
  *     enable_swagger_ui?: bool|Param, // Enable Swagger UI // Default: true
  *     enable_re_doc?: bool|Param, // Enable ReDoc // Default: true
+ *     enable_scalar?: bool|Param, // Enable Scalar API Reference // Default: true
  *     enable_entrypoint?: bool|Param, // Enable the entrypoint // Default: true
  *     enable_docs?: bool|Param, // Enable the docs // Default: true
  *     enable_profiler?: bool|Param, // Enable the data collector and the WebProfilerBundle integration. // Default: true
  *     enable_phpdoc_parser?: bool|Param, // Enable resource metadata collector using PHPStan PhpDocParser. // Default: true
- *     enable_link_security?: bool|Param, // Enable security for Links (sub resources) // Default: false
+ *     enable_link_security?: bool|Param, // Deprecated: This option is always enabled and will be removed in API Platform 5.0. // Enable security for Links (sub resources). // Default: true
  *     collection?: array{
- *         exists_parameter_name?: scalar|null|Param, // The name of the query parameter to filter on nullable field values. // Default: "exists"
- *         order?: scalar|null|Param, // The default order of results. // Default: "ASC"
- *         order_parameter_name?: scalar|null|Param, // The name of the query parameter to order results. // Default: "order"
- *         order_nulls_comparison?: "nulls_smallest"|"nulls_largest"|"nulls_always_first"|"nulls_always_last"|null|Param, // The nulls comparison strategy. // Default: null
+ *         exists_parameter_name?: scalar|Param|null, // The name of the query parameter to filter on nullable field values. // Default: "exists"
+ *         order?: scalar|Param|null, // The default order of results. // Default: "ASC"
+ *         order_parameter_name?: scalar|Param|null, // The name of the query parameter to order results. // Default: "order"
+ *         order_nulls_comparison?: "nulls_smallest"|"nulls_largest"|"nulls_always_first"|"nulls_always_last"|Param|null, // The nulls comparison strategy. // Default: null
  *         pagination?: bool|array{
  *             enabled?: bool|Param, // Default: true
- *             page_parameter_name?: scalar|null|Param, // The default name of the parameter handling the page number. // Default: "page"
- *             enabled_parameter_name?: scalar|null|Param, // The name of the query parameter to enable or disable pagination. // Default: "pagination"
- *             items_per_page_parameter_name?: scalar|null|Param, // The name of the query parameter to set the number of items per page. // Default: "itemsPerPage"
- *             partial_parameter_name?: scalar|null|Param, // The name of the query parameter to enable or disable partial pagination. // Default: "partial"
+ *             page_parameter_name?: scalar|Param|null, // The default name of the parameter handling the page number. // Default: "page"
+ *             enabled_parameter_name?: scalar|Param|null, // The name of the query parameter to enable or disable pagination. // Default: "pagination"
+ *             items_per_page_parameter_name?: scalar|Param|null, // The name of the query parameter to set the number of items per page. // Default: "itemsPerPage"
+ *             partial_parameter_name?: scalar|Param|null, // The name of the query parameter to enable or disable partial pagination. // Default: "partial"
  *         },
  *     },
  *     mapping?: array{
- *         imports?: list<scalar|null|Param>,
- *         paths?: list<scalar|null|Param>,
+ *         imports?: list<scalar|Param|null>,
+ *         paths?: list<scalar|Param|null>,
  *     },
- *     resource_class_directories?: list<scalar|null|Param>,
+ *     resource_class_directories?: list<scalar|Param|null>,
  *     serializer?: array{
  *         hydra_prefix?: bool|Param, // Use the "hydra:" prefix. // Default: false
  *     },
@@ -1492,19 +1505,19 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     oauth?: bool|array{
  *         enabled?: bool|Param, // Default: false
- *         clientId?: scalar|null|Param, // The oauth client id. // Default: ""
- *         clientSecret?: scalar|null|Param, // The OAuth client secret. Never use this parameter in your production environment. It exposes crucial security information. This feature is intended for dev/test environments only. Enable "oauth.pkce" instead // Default: ""
+ *         clientId?: scalar|Param|null, // The oauth client id. // Default: ""
+ *         clientSecret?: scalar|Param|null, // The OAuth client secret. Never use this parameter in your production environment. It exposes crucial security information. This feature is intended for dev/test environments only. Enable "oauth.pkce" instead // Default: ""
  *         pkce?: bool|Param, // Enable the oauth PKCE. // Default: false
- *         type?: scalar|null|Param, // The oauth type. // Default: "oauth2"
- *         flow?: scalar|null|Param, // The oauth flow grant type. // Default: "application"
- *         tokenUrl?: scalar|null|Param, // The oauth token url. // Default: ""
- *         authorizationUrl?: scalar|null|Param, // The oauth authentication url. // Default: ""
- *         refreshUrl?: scalar|null|Param, // The oauth refresh url. // Default: ""
- *         scopes?: list<scalar|null|Param>,
+ *         type?: scalar|Param|null, // The oauth type. // Default: "oauth2"
+ *         flow?: scalar|Param|null, // The oauth flow grant type. // Default: "application"
+ *         tokenUrl?: scalar|Param|null, // The oauth token url. // Default: ""
+ *         authorizationUrl?: scalar|Param|null, // The oauth authentication url. // Default: ""
+ *         refreshUrl?: scalar|Param|null, // The oauth refresh url. // Default: ""
+ *         scopes?: list<scalar|Param|null>,
  *     },
  *     graphql?: bool|array{
  *         enabled?: bool|Param, // Default: false
- *         default_ide?: scalar|null|Param, // Default: "graphiql"
+ *         default_ide?: scalar|Param|null, // Default: "graphiql"
  *         graphiql?: bool|array{
  *             enabled?: bool|Param, // Default: false
  *         },
@@ -1512,9 +1525,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             enabled?: bool|Param, // Default: true
  *         },
  *         max_query_depth?: int|Param, // Default: 20
- *         graphql_playground?: array<mixed>,
+ *         graphql_playground?: bool|array{ // Deprecated: The "graphql_playground" configuration is deprecated and will be ignored.
+ *             enabled?: bool|Param, // Default: false
+ *         },
  *         max_query_complexity?: int|Param, // Default: 500
- *         nesting_separator?: scalar|null|Param, // The separator to use to filter nested fields. // Default: "_"
+ *         nesting_separator?: scalar|Param|null, // The separator to use to filter nested fields. // Default: "_"
  *         collection?: array{
  *             pagination?: bool|array{
  *                 enabled?: bool|Param, // Default: true
@@ -1523,35 +1538,35 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     swagger?: array{
  *         persist_authorization?: bool|Param, // Persist the SwaggerUI Authorization in the localStorage. // Default: false
- *         versions?: list<scalar|null|Param>,
+ *         versions?: list<scalar|Param|null>,
  *         api_keys?: array<string, array{ // Default: []
- *             name?: scalar|null|Param, // The name of the header or query parameter containing the api key.
+ *             name?: scalar|Param|null, // The name of the header or query parameter containing the api key.
  *             type?: "query"|"header"|Param, // Whether the api key should be a query parameter or a header.
  *         }>,
  *         http_auth?: array<string, array{ // Default: []
- *             scheme?: scalar|null|Param, // The OpenAPI HTTP auth scheme, for example "bearer"
- *             bearerFormat?: scalar|null|Param, // The OpenAPI HTTP bearer format
+ *             scheme?: scalar|Param|null, // The OpenAPI HTTP auth scheme, for example "bearer"
+ *             bearerFormat?: scalar|Param|null, // The OpenAPI HTTP bearer format
  *         }>,
  *         swagger_ui_extra_configuration?: mixed, // To pass extra configuration to Swagger UI, like docExpansion or filter. // Default: []
  *     },
  *     http_cache?: array{
- *         public?: bool|null|Param, // To make all responses public by default. // Default: null
+ *         public?: bool|Param|null, // To make all responses public by default. // Default: null
  *         invalidation?: bool|array{ // Enable the tags-based cache invalidation system.
  *             enabled?: bool|Param, // Default: false
- *             varnish_urls?: list<scalar|null|Param>,
- *             urls?: list<scalar|null|Param>,
- *             scoped_clients?: list<scalar|null|Param>,
+ *             varnish_urls?: list<scalar|Param|null>,
+ *             urls?: list<scalar|Param|null>,
+ *             scoped_clients?: list<scalar|Param|null>,
  *             max_header_length?: int|Param, // Max header length supported by the cache server. // Default: 7500
  *             request_options?: mixed, // To pass options to the client charged with the request. // Default: []
- *             purger?: scalar|null|Param, // Specify a purger to use (available values: "api_platform.http_cache.purger.varnish.ban", "api_platform.http_cache.purger.varnish.xkey", "api_platform.http_cache.purger.souin"). // Default: "api_platform.http_cache.purger.varnish"
- *             xkey?: array{ // Deprecated: The "xkey" configuration is deprecated, use your own purger to customize surrogate keys or the appropriate paramters.
- *                 glue?: scalar|null|Param, // xkey glue between keys // Default: " "
+ *             purger?: scalar|Param|null, // Specify a purger to use (available values: "api_platform.http_cache.purger.varnish.ban", "api_platform.http_cache.purger.varnish.xkey", "api_platform.http_cache.purger.souin"). // Default: "api_platform.http_cache.purger.varnish"
+ *             xkey?: array{ // Deprecated: The "xkey" configuration is deprecated, use your own purger to customize surrogate keys or the appropriate parameters.
+ *                 glue?: scalar|Param|null, // xkey glue between keys // Default: " "
  *             },
  *         },
  *     },
  *     mercure?: bool|array{
  *         enabled?: bool|Param, // Default: false
- *         hub_url?: scalar|null|Param, // The URL sent in the Link HTTP header. If not set, will default to the URL for MercureBundle's default hub. // Default: null
+ *         hub_url?: scalar|Param|null, // The URL sent in the Link HTTP header. If not set, will default to the URL for MercureBundle's default hub. // Default: null
  *         include_type?: bool|Param, // Always include @type in updates (including delete ones). // Default: false
  *     },
  *     messenger?: bool|array{
@@ -1559,46 +1574,55 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     elasticsearch?: bool|array{
  *         enabled?: bool|Param, // Default: false
- *         hosts?: list<scalar|null|Param>,
+ *         hosts?: list<scalar|Param|null>,
+ *         ssl_ca_bundle?: scalar|Param|null, // Path to the SSL CA bundle file for Elasticsearch SSL verification. // Default: null
+ *         ssl_verification?: bool|Param, // Enable or disable SSL verification for Elasticsearch connections. // Default: true
+ *         client?: "elasticsearch"|"opensearch"|Param, // The search engine client to use: "elasticsearch" or "opensearch". // Default: "elasticsearch"
  *     },
  *     openapi?: array{
  *         contact?: array{
- *             name?: scalar|null|Param, // The identifying name of the contact person/organization. // Default: null
- *             url?: scalar|null|Param, // The URL pointing to the contact information. MUST be in the format of a URL. // Default: null
- *             email?: scalar|null|Param, // The email address of the contact person/organization. MUST be in the format of an email address. // Default: null
+ *             name?: scalar|Param|null, // The identifying name of the contact person/organization. // Default: null
+ *             url?: scalar|Param|null, // The URL pointing to the contact information. MUST be in the format of a URL. // Default: null
+ *             email?: scalar|Param|null, // The email address of the contact person/organization. MUST be in the format of an email address. // Default: null
  *         },
- *         termsOfService?: scalar|null|Param, // A URL to the Terms of Service for the API. MUST be in the format of a URL. // Default: null
+ *         termsOfService?: scalar|Param|null, // A URL to the Terms of Service for the API. MUST be in the format of a URL. // Default: null
  *         tags?: list<array{ // Default: []
- *             name: scalar|null|Param,
- *             description?: scalar|null|Param, // Default: null
+ *             name?: scalar|Param|null,
+ *             description?: scalar|Param|null, // Default: null
  *         }>,
  *         license?: array{
- *             name?: scalar|null|Param, // The license name used for the API. // Default: null
- *             url?: scalar|null|Param, // URL to the license used for the API. MUST be in the format of a URL. // Default: null
- *             identifier?: scalar|null|Param, // An SPDX license expression for the API. The identifier field is mutually exclusive of the url field. // Default: null
+ *             name?: scalar|Param|null, // The license name used for the API. // Default: null
+ *             url?: scalar|Param|null, // URL to the license used for the API. MUST be in the format of a URL. // Default: null
+ *             identifier?: scalar|Param|null, // An SPDX license expression for the API. The identifier field is mutually exclusive of the url field. // Default: null
  *         },
  *         swagger_ui_extra_configuration?: mixed, // To pass extra configuration to Swagger UI, like docExpansion or filter. // Default: []
+ *         scalar_extra_configuration?: mixed, // To pass extra configuration to Scalar API Reference, like theme or darkMode. // Default: []
  *         overrideResponses?: bool|Param, // Whether API Platform adds automatic responses to the OpenAPI documentation. // Default: true
- *         error_resource_class?: scalar|null|Param, // The class used to represent errors in the OpenAPI documentation. // Default: null
- *         validation_error_resource_class?: scalar|null|Param, // The class used to represent validation errors in the OpenAPI documentation. // Default: null
+ *         error_resource_class?: scalar|Param|null, // The class used to represent errors in the OpenAPI documentation. // Default: null
+ *         validation_error_resource_class?: scalar|Param|null, // The class used to represent validation errors in the OpenAPI documentation. // Default: null
  *     },
  *     maker?: bool|array{
  *         enabled?: bool|Param, // Default: true
+ *         namespace_prefix?: scalar|Param|null, // Add a prefix to all maker generated classes. e.g set it to "Api" to set the maker namespace to "App\Api\" (if the maker.root_namespace config is App). e.g. App\Api\State\MyStateProcessor // Default: ""
+ *     },
+ *     mcp?: bool|array{
+ *         enabled?: bool|Param, // Default: true
+ *         format?: scalar|Param|null, // The serialization format used for MCP tool input/output. Must be a format registered in api_platform.formats (e.g. "jsonld", "json", "jsonapi"). // Default: "jsonld"
  *     },
  *     exception_to_status?: array<string, int|Param>,
  *     formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]}}
- *         mime_types?: list<scalar|null|Param>,
+ *         mime_types?: list<scalar|Param|null>,
  *     }>,
  *     patch_formats?: array<string, array{ // Default: {"json":{"mime_types":["application/merge-patch+json"]}}
- *         mime_types?: list<scalar|null|Param>,
+ *         mime_types?: list<scalar|Param|null>,
  *     }>,
  *     docs_formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]},"jsonopenapi":{"mime_types":["application/vnd.openapi+json"]},"html":{"mime_types":["text/html"]},"yamlopenapi":{"mime_types":["application/vnd.openapi+yaml"]}}
- *         mime_types?: list<scalar|null|Param>,
+ *         mime_types?: list<scalar|Param|null>,
  *     }>,
  *     error_formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]},"jsonproblem":{"mime_types":["application/problem+json"]},"json":{"mime_types":["application/problem+json","application/json"]}}
- *         mime_types?: list<scalar|null|Param>,
+ *         mime_types?: list<scalar|Param|null>,
  *     }>,
- *     jsonschema_formats?: list<scalar|null|Param>,
+ *     jsonschema_formats?: list<scalar|Param|null>,
  *     defaults?: array{
  *         uri_template?: mixed,
  *         short_name?: mixed,
@@ -1668,12 +1692,37 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         rules?: mixed,
  *         policy?: mixed,
  *         middleware?: mixed,
- *         parameters?: mixed,
+ *         parameters?: array<string, array{ // Default: []
+ *             key?: mixed,
+ *             schema?: mixed,
+ *             open_api?: mixed,
+ *             provider?: mixed,
+ *             filter?: mixed,
+ *             property?: mixed,
+ *             description?: mixed,
+ *             properties?: mixed,
+ *             required?: mixed,
+ *             priority?: mixed,
+ *             hydra?: mixed,
+ *             constraints?: mixed,
+ *             security?: mixed,
+ *             security_message?: mixed,
+ *             extra_properties?: mixed,
+ *             filter_context?: mixed,
+ *             native_type?: mixed,
+ *             cast_to_array?: mixed,
+ *             cast_to_native_type?: mixed,
+ *             cast_fn?: mixed,
+ *             default?: mixed,
+ *             filter_class?: mixed,
+ *             ...<string, mixed>
+ *         }>,
  *         strict_query_parameter_validation?: mixed,
  *         hide_hydra_operation?: mixed,
  *         json_stream?: mixed,
  *         extra_properties?: mixed,
  *         map?: mixed,
+ *         mcp?: mixed,
  *         route_name?: mixed,
  *         errors?: mixed,
  *         read?: mixed,
@@ -1681,170 +1730,183 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         validate?: mixed,
  *         write?: mixed,
  *         serialize?: mixed,
+ *         content_negotiation?: mixed,
  *         priority?: mixed,
  *         name?: mixed,
  *         allow_create?: mixed,
  *         item_uri_template?: mixed,
- *         ...<mixed>
+ *         ...<string, mixed>
  *     },
  * }
  * @psalm-type ZenstruckFoundryConfig = array{
- *     auto_refresh_proxies?: bool|null|Param, // Deprecated: Since 2.0 auto_refresh_proxies defaults to true and this configuration has no effect. // Whether to auto-refresh proxies by default (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh) // Default: null
- *     enable_auto_refresh_with_lazy_objects?: bool|null|Param, // Enable auto-refresh using PHP 8.4 lazy objects (cannot be enabled if PHP < 8.4). // Default: null
+ *     auto_refresh_proxies?: bool|Param|null, // Deprecated: Since 2.0 auto_refresh_proxies defaults to true and this configuration has no effect. // Whether to auto-refresh proxies by default (https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#auto-refresh) // Default: null
+ *     enable_auto_refresh_with_lazy_objects?: bool|Param|null, // Enable auto-refresh using PHP 8.4 lazy objects (cannot be enabled if PHP < 8.4). // Default: null
  *     faker?: array{ // Configure the faker used by your factories.
- *         locale?: scalar|null|Param, // The default locale to use for faker. // Default: null
- *         seed?: scalar|null|Param, // Deprecated: The "faker.seed" configuration is deprecated and will be removed in 3.0. Use environment variable "FOUNDRY_FAKER_SEED" instead. // Random number generator seed to produce the same fake values every run. // Default: null
- *         service?: scalar|null|Param, // Service id for custom faker instance. // Default: null
+ *         locale?: scalar|Param|null, // The default locale to use for faker. // Default: null
+ *         seed?: scalar|Param|null, // Deprecated: The "faker.seed" configuration is deprecated and will be removed in 3.0. Use environment variable "FOUNDRY_FAKER_SEED" instead. // Random number generator seed to produce the same fake values every run. // Default: null
+ *         manage_seed?: bool|Param, // Automatically manage faker seed to ensure consistent data between test runs. // Default: true
+ *         service?: scalar|Param|null, // Service id for custom faker instance. // Default: null
  *     },
  *     instantiator?: array{ // Configure the default instantiator used by your object factories.
  *         use_constructor?: bool|Param, // Use the constructor to instantiate objects. // Default: true
  *         allow_extra_attributes?: bool|Param, // Whether or not to skip attributes that do not correspond to properties. // Default: false
  *         always_force_properties?: bool|Param, // Whether or not to skip setters and force set object properties (public/private/protected) directly. // Default: false
- *         service?: scalar|null|Param, // Service id of your custom instantiator. // Default: null
+ *         service?: scalar|Param|null, // Service id of your custom instantiator. // Default: null
  *     },
- *     global_state?: list<scalar|null|Param>,
+ *     global_state?: list<scalar|Param|null>,
  *     persistence?: array{
  *         flush_once?: bool|Param, // Flush only once per call of `PersistentObjectFactory::create()` in userland. // Default: false
  *     },
  *     orm?: array{
  *         auto_persist?: bool|Param, // Deprecated: Since 2.4 auto_persist defaults to true and this configuration has no effect. // Automatically persist entities when created. // Default: true
  *         reset?: array{
- *             connections?: list<scalar|null|Param>,
- *             entity_managers?: list<scalar|null|Param>,
+ *             connections?: list<scalar|Param|null>,
+ *             entity_managers?: list<scalar|Param|null>,
  *             mode?: \Zenstruck\Foundry\ORM\ResetDatabase\ResetDatabaseMode::SCHEMA|\Zenstruck\Foundry\ORM\ResetDatabase\ResetDatabaseMode::MIGRATE|Param, // Reset mode to use with ResetDatabase trait // Default: "schema"
  *             migrations?: array{
- *                 configurations?: list<scalar|null|Param>,
+ *                 configurations?: list<scalar|Param|null>,
  *             },
  *         },
  *     },
  *     mongo?: array{
  *         auto_persist?: bool|Param, // Deprecated: Since 2.4 auto_persist defaults to true and this configuration has no effect. // Automatically persist documents when created. // Default: true
  *         reset?: array{
- *             document_managers?: list<scalar|null|Param>,
+ *             document_managers?: list<scalar|Param|null>,
  *         },
  *     },
  *     make_factory?: array{
- *         default_namespace?: scalar|null|Param, // Default namespace where factories will be created by maker. // Default: "Factory"
+ *         default_namespace?: scalar|Param|null, // Default namespace where factories will be created by maker. // Default: "Factory"
  *         add_hints?: bool|Param, // Add "beginner" hints in the created factory. // Default: true
  *     },
  *     make_story?: array{
- *         default_namespace?: scalar|null|Param, // Default namespace where stories will be created by maker. // Default: "Story"
+ *         default_namespace?: scalar|Param|null, // Default namespace where stories will be created by maker. // Default: "Story"
  *     },
  * }
  * @psalm-type SncRedisConfig = array{
  *     class?: array{
- *         client?: scalar|null|Param, // Default: "Predis\\Client"
- *         client_options?: scalar|null|Param, // Default: "Predis\\Configuration\\Options"
- *         connection_parameters?: scalar|null|Param, // Default: "Predis\\Connection\\Parameters"
- *         connection_factory?: scalar|null|Param, // Default: "Snc\\RedisBundle\\Client\\Predis\\Connection\\ConnectionFactory"
- *         connection_wrapper?: scalar|null|Param, // Default: "Snc\\RedisBundle\\Client\\Predis\\Connection\\ConnectionWrapper"
- *         phpredis_client?: scalar|null|Param, // Default: "Redis"
- *         relay_client?: scalar|null|Param, // Default: "Relay\\Relay"
- *         phpredis_clusterclient?: scalar|null|Param, // Default: "RedisCluster"
- *         logger?: scalar|null|Param, // Default: "Snc\\RedisBundle\\Logger\\RedisLogger"
- *         data_collector?: scalar|null|Param, // Default: "Snc\\RedisBundle\\DataCollector\\RedisDataCollector"
- *         monolog_handler?: scalar|null|Param, // Default: "Monolog\\Handler\\RedisHandler"
+ *         client?: scalar|Param|null, // Default: "Predis\\Client"
+ *         client_options?: scalar|Param|null, // Default: "Predis\\Configuration\\Options"
+ *         connection_parameters?: scalar|Param|null, // Default: "Predis\\Connection\\Parameters"
+ *         connection_factory?: scalar|Param|null, // Default: "Snc\\RedisBundle\\Client\\Predis\\Connection\\ConnectionFactory"
+ *         connection_wrapper?: scalar|Param|null, // Default: "Snc\\RedisBundle\\Client\\Predis\\Connection\\ConnectionWrapper"
+ *         phpredis_client?: scalar|Param|null, // Default: "Redis"
+ *         relay_client?: scalar|Param|null, // Default: "Relay\\Relay"
+ *         phpredis_clusterclient?: scalar|Param|null, // Default: "RedisCluster"
+ *         phpredis_arrayclient?: scalar|Param|null, // Default: "RedisArray"
+ *         logger?: scalar|Param|null, // Default: "Snc\\RedisBundle\\Logger\\RedisLogger"
+ *         data_collector?: scalar|Param|null, // Default: "Snc\\RedisBundle\\DataCollector\\RedisDataCollector"
+ *         monolog_handler?: scalar|Param|null, // Default: "Monolog\\Handler\\RedisHandler"
  *     },
  *     clients?: array<string, array{ // Default: []
- *         type: scalar|null|Param,
- *         alias: scalar|null|Param,
+ *         type?: scalar|Param|null,
+ *         alias?: scalar|Param|null,
+ *         class?: scalar|Param|null, // Default: null
  *         logging?: bool|Param, // Default: true
- *         dsns: list<mixed>,
+ *         dsns?: string|list<mixed>,
  *         options?: array{
- *             commands?: array<string, scalar|null|Param>,
+ *             commands?: array<string, scalar|Param|null>,
  *             connection_async?: bool|Param, // Default: false
  *             connection_persistent?: mixed, // Default: false
- *             connection_timeout?: scalar|null|Param, // Default: 5
- *             read_write_timeout?: scalar|null|Param, // Default: null
+ *             connection_timeout?: scalar|Param|null, // Default: 5
+ *             scan?: int|Param, // Default: null
+ *             read_write_timeout?: scalar|Param|null, // Default: null
  *             iterable_multibulk?: bool|Param, // Default: false
  *             throw_errors?: bool|Param, // Default: true
- *             serialization?: scalar|null|Param, // Default: "default"
- *             cluster?: scalar|null|Param, // Default: null
- *             prefix?: scalar|null|Param, // Default: null
+ *             serialization?: scalar|Param|null, // Default: "default"
+ *             compression?: scalar|Param|null, // Default: null
+ *             compression_level?: int|Param, // Default: null
+ *             cluster?: scalar|Param|null, // Default: null
+ *             array?: bool|Param, // Default: false
+ *             prefix?: scalar|Param|null, // Default: null
  *             replication?: true|"predis"|"sentinel"|Param,
- *             service?: scalar|null|Param, // Default: null
+ *             service?: scalar|Param|null, // Default: null
  *             slave_failover?: "none"|"error"|"distribute"|"distribute_slaves"|Param,
  *             parameters?: array{
- *                 database?: scalar|null|Param, // Default: null
- *                 username?: scalar|null|Param, // Default: null
- *                 password?: scalar|null|Param, // Default: null
- *                 sentinel_username?: scalar|null|Param, // Default: null
- *                 sentinel_password?: scalar|null|Param, // Default: null
+ *                 database?: scalar|Param|null, // Default: null
+ *                 username?: scalar|Param|null, // Default: null
+ *                 password?: scalar|Param|null, // Default: null
+ *                 sentinel_username?: scalar|Param|null, // Default: null
+ *                 sentinel_password?: scalar|Param|null, // Default: null
  *                 logging?: bool|Param, // Default: true
  *                 ssl_context?: mixed, // Default: null
  *             },
  *         },
  *     }>,
  *     monolog?: array{
- *         client: scalar|null|Param,
- *         key: scalar|null|Param,
- *         formatter?: scalar|null|Param,
+ *         client?: scalar|Param|null,
+ *         key?: scalar|Param|null,
+ *         formatter?: scalar|Param|null,
  *     },
  * }
  * @psalm-type SentryConfig = array{
- *     dsn?: scalar|null|Param, // If this value is not provided, the SDK will try to read it from the SENTRY_DSN environment variable. If that variable also does not exist, the SDK will not send any events.
+ *     dsn?: scalar|Param|null, // If this value is not provided, the SDK will try to read it from the SENTRY_DSN environment variable. If that variable also does not exist, the SDK will not send any events.
  *     register_error_listener?: bool|Param, // Default: true
  *     register_error_handler?: bool|Param, // Default: true
- *     logger?: scalar|null|Param, // The service ID of the PSR-3 logger used to log messages coming from the SDK client. Be aware that setting the same logger of the application may create a circular loop when an event fails to be sent. // Default: null
+ *     logger?: scalar|Param|null, // The service ID of the PSR-3 logger used to log messages coming from the SDK client. Be aware that setting the same logger of the application may create a circular loop when an event fails to be sent. // Default: null
  *     options?: array{
  *         integrations?: mixed, // Default: []
  *         default_integrations?: bool|Param,
- *         prefixes?: list<scalar|null|Param>,
+ *         prefixes?: list<scalar|Param|null>,
  *         sample_rate?: float|Param, // The sampling factor to apply to events. A value of 0 will deny sending any event, and a value of 1 will send all events.
  *         enable_tracing?: bool|Param,
  *         traces_sample_rate?: float|Param, // The sampling factor to apply to transactions. A value of 0 will deny sending any transaction, and a value of 1 will send all transactions.
- *         traces_sampler?: scalar|null|Param,
+ *         traces_sampler?: scalar|Param|null,
  *         profiles_sample_rate?: float|Param, // The sampling factor to apply to profiles. A value of 0 will deny sending any profiles, and a value of 1 will send all profiles. Profiles are sampled in relation to traces_sample_rate
  *         enable_logs?: bool|Param,
+ *         log_flush_threshold?: mixed, // Default: null
  *         enable_metrics?: bool|Param, // Default: true
  *         attach_stacktrace?: bool|Param,
  *         attach_metric_code_locations?: bool|Param,
  *         context_lines?: int|Param,
- *         environment?: scalar|null|Param, // Default: "%kernel.environment%"
- *         logger?: scalar|null|Param,
+ *         environment?: scalar|Param|null, // Default: "%kernel.environment%"
+ *         logger?: scalar|Param|null,
  *         spotlight?: bool|Param,
- *         spotlight_url?: scalar|null|Param,
- *         release?: scalar|null|Param, // Default: "%env(default::SENTRY_RELEASE)%"
- *         server_name?: scalar|null|Param,
- *         ignore_exceptions?: list<scalar|null|Param>,
- *         ignore_transactions?: list<scalar|null|Param>,
- *         before_send?: scalar|null|Param,
- *         before_send_transaction?: scalar|null|Param,
- *         before_send_check_in?: scalar|null|Param,
- *         before_send_metrics?: scalar|null|Param,
- *         before_send_log?: scalar|null|Param,
- *         before_send_metric?: scalar|null|Param,
+ *         spotlight_url?: scalar|Param|null,
+ *         release?: scalar|Param|null, // Default: "%env(default::SENTRY_RELEASE)%"
+ *         org_id?: int|Param,
+ *         server_name?: scalar|Param|null,
+ *         ignore_exceptions?: list<scalar|Param|null>,
+ *         ignore_transactions?: list<scalar|Param|null>,
+ *         before_send?: scalar|Param|null,
+ *         before_send_transaction?: scalar|Param|null,
+ *         before_send_check_in?: scalar|Param|null,
+ *         before_send_metrics?: scalar|Param|null,
+ *         before_send_log?: scalar|Param|null,
+ *         before_send_metric?: scalar|Param|null,
  *         trace_propagation_targets?: mixed,
- *         tags?: array<string, scalar|null|Param>,
- *         error_types?: scalar|null|Param,
+ *         strict_trace_continuation?: bool|Param,
+ *         tags?: array<string, scalar|Param|null>,
+ *         error_types?: scalar|Param|null,
  *         max_breadcrumbs?: int|Param,
  *         before_breadcrumb?: mixed,
- *         in_app_exclude?: list<scalar|null|Param>,
- *         in_app_include?: list<scalar|null|Param>,
+ *         in_app_exclude?: list<scalar|Param|null>,
+ *         in_app_include?: list<scalar|Param|null>,
  *         send_default_pii?: bool|Param,
  *         max_value_length?: int|Param,
- *         transport?: scalar|null|Param,
- *         http_client?: scalar|null|Param,
- *         http_proxy?: scalar|null|Param,
- *         http_proxy_authentication?: scalar|null|Param,
+ *         transport?: scalar|Param|null,
+ *         http_client?: scalar|Param|null,
+ *         http_proxy?: scalar|Param|null,
+ *         http_proxy_authentication?: scalar|Param|null,
  *         http_connect_timeout?: float|Param, // The maximum number of seconds to wait while trying to connect to a server. It works only when using the default transport.
  *         http_timeout?: float|Param, // The maximum execution time for the request+response as a whole. It works only when using the default transport.
  *         http_ssl_verify_peer?: bool|Param,
  *         http_compression?: bool|Param,
  *         capture_silenced_errors?: bool|Param,
  *         max_request_body_size?: "none"|"never"|"small"|"medium"|"always"|Param,
- *         class_serializers?: array<string, scalar|null|Param>,
+ *         class_serializers?: array<string, scalar|Param|null>,
  *     },
  *     messenger?: bool|array{
  *         enabled?: bool|Param, // Default: true
  *         capture_soft_fails?: bool|Param, // Default: true
  *         isolate_breadcrumbs_by_message?: bool|Param, // Default: false
+ *         isolate_context_by_message?: bool|Param, // Default: false
  *     },
  *     tracing?: bool|array{
  *         enabled?: bool|Param, // Default: true
  *         dbal?: bool|array{
  *             enabled?: bool|Param, // Default: true
- *             connections?: list<scalar|null|Param>,
+ *             ignore_prepare_spans?: bool|Param, // Default: false
+ *             connections?: list<scalar|Param|null>,
  *         },
  *         twig?: bool|array{
  *             enabled?: bool|Param, // Default: true
@@ -1856,7 +1918,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             enabled?: bool|Param, // Default: true
  *         },
  *         console?: array{
- *             excluded_commands?: list<scalar|null|Param>,
+ *             excluded_commands?: list<scalar|Param|null>,
  *         },
  *     },
  * }
@@ -1868,10 +1930,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type UtilZitadelConfig = array{
  *     user?: array{
- *         class?: scalar|null|Param,
+ *         class?: scalar|Param|null,
  *     },
  * }
- * @psalm-type CoreConfig = array<mixed>
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1886,7 +1947,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     api_platform?: ApiPlatformConfig,
  *     snc_redis?: SncRedisConfig,
  *     util_zitadel?: UtilZitadelConfig,
- *     core?: CoreConfig,
  *     "when@dev"?: array{
  *         imports?: ImportsConfig,
  *         parameters?: ParametersConfig,
@@ -1905,7 +1965,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         zenstruck_foundry?: ZenstruckFoundryConfig,
  *         snc_redis?: SncRedisConfig,
  *         util_zitadel?: UtilZitadelConfig,
- *         core?: CoreConfig,
  *     },
  *     "when@prod"?: array{
  *         imports?: ImportsConfig,
@@ -1922,7 +1981,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         snc_redis?: SncRedisConfig,
  *         sentry?: SentryConfig,
  *         util_zitadel?: UtilZitadelConfig,
- *         core?: CoreConfig,
  *     },
  *     "when@test"?: array{
  *         imports?: ImportsConfig,
@@ -1942,7 +2000,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         snc_redis?: SncRedisConfig,
  *         dama_doctrine_test?: DamaDoctrineTestConfig,
  *         util_zitadel?: UtilZitadelConfig,
- *         core?: CoreConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,
@@ -1961,7 +2018,10 @@ final class App
      */
     public static function config(array $config): array
     {
-        return AppReference::config($config);
+        /** @var ConfigType $config */
+        $config = AppReference::config($config);
+
+        return $config;
     }
 }
 

--- a/projects/espace/api/migrations/Version20260824120000.php
+++ b/projects/espace/api/migrations/Version20260824120000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineDefaultMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260824120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Link an AreaProposal to its proposer (Person).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE area_proposal ADD proposer_id INT NOT NULL');
+        $this->addSql('ALTER TABLE area_proposal ADD CONSTRAINT FK_AREA_PROPOSAL_PROPOSER FOREIGN KEY (proposer_id) REFERENCES person (id)');
+        $this->addSql('CREATE INDEX IDX_AREA_PROPOSAL_PROPOSER ON area_proposal (proposer_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE area_proposal DROP CONSTRAINT FK_AREA_PROPOSAL_PROPOSER');
+        $this->addSql('DROP INDEX IDX_AREA_PROPOSAL_PROPOSER');
+        $this->addSql('ALTER TABLE area_proposal DROP proposer_id');
+    }
+}

--- a/projects/espace/api/migrations/Version20260824120000.php
+++ b/projects/espace/api/migrations/Version20260824120000.php
@@ -18,13 +18,15 @@ final class Version20260824120000 extends AbstractMigration
     {
         $this->addSql('ALTER TABLE area_proposal ADD proposer_id INT NOT NULL');
         $this->addSql('ALTER TABLE area_proposal ADD CONSTRAINT FK_AREA_PROPOSAL_PROPOSER FOREIGN KEY (proposer_id) REFERENCES person (id)');
-        $this->addSql('CREATE INDEX IDX_AREA_PROPOSAL_PROPOSER ON area_proposal (proposer_id)');
+        // Named to match Doctrine's default hash-based index name (see doctrine:schema:validate),
+        // instead of the FK_/IDX_AREA_PROPOSAL_PROPOSER convention used elsewhere in this codebase.
+        $this->addSql('CREATE INDEX IDX_7CEACABAB13FA634 ON area_proposal (proposer_id)');
     }
 
     public function down(Schema $schema): void
     {
         $this->addSql('ALTER TABLE area_proposal DROP CONSTRAINT FK_AREA_PROPOSAL_PROPOSER');
-        $this->addSql('DROP INDEX IDX_AREA_PROPOSAL_PROPOSER');
+        $this->addSql('DROP INDEX IDX_7CEACABAB13FA634');
         $this->addSql('ALTER TABLE area_proposal DROP proposer_id');
     }
 }

--- a/projects/espace/api/migrations/Version20260829140000.php
+++ b/projects/espace/api/migrations/Version20260829140000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineDefaultMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260829140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rename area_request indexes to match Doctrine default hash-based names (doctrine:schema:validate was failing).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER INDEX idx_area_request_requester RENAME TO IDX_3847E662ED442CF4');
+        $this->addSql('ALTER INDEX idx_area_request_area_activity_request RENAME TO IDX_75B6888ACD8E5A1F');
+        $this->addSql('ALTER INDEX idx_area_request_area_activity_activity RENAME TO IDX_75B6888AAAFBCAE6');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER INDEX idx_75b6888aaafbcae6 RENAME TO IDX_AREA_REQUEST_AREA_ACTIVITY_ACTIVITY');
+        $this->addSql('ALTER INDEX idx_75b6888acd8e5a1f RENAME TO IDX_AREA_REQUEST_AREA_ACTIVITY_REQUEST');
+        $this->addSql('ALTER INDEX idx_3847e662ed442cf4 RENAME TO IDX_AREA_REQUEST_REQUESTER');
+    }
+}

--- a/projects/espace/api/src/Api/Resource/AreaProposal/AreaProposal.php
+++ b/projects/espace/api/src/Api/Resource/AreaProposal/AreaProposal.php
@@ -51,6 +51,7 @@ final class AreaProposal
     use CreatedAtTrait;
     use PlaceTrait;
     use ActivitiesAsStringTrait;
+    use ProposerTrait;
 
     public ?string $title;
     public ?string $description;

--- a/projects/espace/api/src/Api/Resource/AreaProposal/Dto/AreaProposalCollection.php
+++ b/projects/espace/api/src/Api/Resource/AreaProposal/Dto/AreaProposalCollection.php
@@ -2,6 +2,7 @@
 
 namespace App\Api\Resource\AreaProposal\Dto;
 
+use App\Api\Resource\AreaProposal\ProposerTrait;
 use App\Api\Trait\ActivitiesAsStringTrait;
 use App\Api\Trait\PlaceTrait;
 use App\Api\Trait\UuidIdentifierTrait;
@@ -14,6 +15,7 @@ final class AreaProposalCollection
     use UuidIdentifierTrait;
     use PlaceTrait;
     use ActivitiesAsStringTrait;
+    use ProposerTrait;
 
     public ?string $title;
     public ?string $description;

--- a/projects/espace/api/src/Api/Resource/AreaProposal/ProposerTrait.php
+++ b/projects/espace/api/src/Api/Resource/AreaProposal/ProposerTrait.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Api\Resource\AreaProposal;
+
+use App\Entity\Person;
+
+trait ProposerTrait
+{
+    public ?string $proposerFirstName = null;
+    public ?string $proposerLastName = null;
+
+    public function setProposer(Person $proposer): void
+    {
+        $this->proposerFirstName = $proposer->getGivenName();
+        $this->proposerLastName = $proposer->getFamilyName();
+    }
+}

--- a/projects/espace/api/src/DataFixtures/AreaProposalFixtures.php
+++ b/projects/espace/api/src/DataFixtures/AreaProposalFixtures.php
@@ -18,6 +18,7 @@ class AreaProposalFixtures extends Fixture implements DependentFixtureInterface
     {
         return [
             AreaActivityFixtures::class,
+            PersonFixtures::class,
         ];
     }
 }

--- a/projects/espace/api/src/Doctrine/Listener/AreaProposalLinkProposerListener.php
+++ b/projects/espace/api/src/Doctrine/Listener/AreaProposalLinkProposerListener.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Doctrine\Listener;
+
+use App\Entity\AreaProposal;
+use App\Entity\Person;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Events;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Symfony\Bundle\SecurityBundle\Security;
+
+#[AsEntityListener(event: Events::prePersist, entity: AreaProposal::class)]
+final readonly class AreaProposalLinkProposerListener
+{
+    public function __construct(private Security $security)
+    {
+    }
+
+    /**
+     * @param LifecycleEventArgs<EntityManagerInterface> $event
+     */
+    public function __invoke(AreaProposal $areaProposal, LifecycleEventArgs $event): void
+    {
+        if ($areaProposal->getProposer()) {
+            return;
+        }
+
+        $proposer = $this->security->getUser();
+        if (!$proposer instanceof Person) {
+            return;
+        }
+
+        $areaProposal->setProposer($proposer);
+    }
+}

--- a/projects/espace/api/src/Entity/AreaProposal.php
+++ b/projects/espace/api/src/Entity/AreaProposal.php
@@ -29,6 +29,10 @@ class AreaProposal extends AbstractIdOrmAndUuidApiIdentified
     #[Choice(choices: AreaProposalWorkflow::PLACES)]
     private string $place = AreaProposalWorkflow::PLACE_DRAFT;
 
+    #[ORM\ManyToOne(inversedBy: 'areaProposals')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Person $proposer = null;
+
     #[ORM\Column(nullable: true)]
     private ?\DateTimeImmutable $archivedAt = null;
 
@@ -90,6 +94,18 @@ class AreaProposal extends AbstractIdOrmAndUuidApiIdentified
     public function setPlace(string $place): static
     {
         $this->place = $place;
+
+        return $this;
+    }
+
+    public function getProposer(): ?Person
+    {
+        return $this->proposer;
+    }
+
+    public function setProposer(?Person $proposer): static
+    {
+        $this->proposer = $proposer;
 
         return $this;
     }

--- a/projects/espace/api/src/Entity/AreaRequest.php
+++ b/projects/espace/api/src/Entity/AreaRequest.php
@@ -20,9 +20,6 @@ class AreaRequest extends AbstractIdOrmAndUuidApiIdentified
     use CreatedAtTrait;
 
     #[ORM\Column(length: 255)]
-    private ?string $state = null;
-
-    #[ORM\Column(length: 255)]
     private ?string $title = null;
 
     #[ORM\Column(type: Types::TEXT)]
@@ -56,18 +53,6 @@ class AreaRequest extends AbstractIdOrmAndUuidApiIdentified
     {
         parent::__construct();
         $this->activities = new ArrayCollection();
-    }
-
-    public function getState(): ?string
-    {
-        return $this->state;
-    }
-
-    public function setState(string $state): static
-    {
-        $this->state = $state;
-
-        return $this;
     }
 
     public function getTitle(): ?string

--- a/projects/espace/api/src/Entity/Person.php
+++ b/projects/espace/api/src/Entity/Person.php
@@ -19,9 +19,16 @@ class Person extends AbstractZitadelUser
     #[ORM\OneToMany(targetEntity: AreaRequest::class, mappedBy: 'requester', orphanRemoval: true)]
     private Collection $areaRequests;
 
+    /**
+     * @var Collection<int, AreaProposal>
+     */
+    #[ORM\OneToMany(targetEntity: AreaProposal::class, mappedBy: 'proposer', orphanRemoval: true)]
+    private Collection $areaProposals;
+
     public function __construct()
     {
         $this->areaRequests = new ArrayCollection();
+        $this->areaProposals = new ArrayCollection();
     }
 
     /**
@@ -47,6 +54,35 @@ class Person extends AbstractZitadelUser
         if ($this->areaRequests->removeElement($areaRequest)) {
             if ($areaRequest->getRequester() === $this) {
                 $areaRequest->setRequester(null);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, AreaProposal>
+     */
+    public function getAreaProposals(): Collection
+    {
+        return $this->areaProposals;
+    }
+
+    public function addAreaProposal(AreaProposal $areaProposal): static
+    {
+        if (!$this->areaProposals->contains($areaProposal)) {
+            $this->areaProposals->add($areaProposal);
+            $areaProposal->setProposer($this);
+        }
+
+        return $this;
+    }
+
+    public function removeAreaProposal(AreaProposal $areaProposal): static
+    {
+        if ($this->areaProposals->removeElement($areaProposal)) {
+            if ($areaProposal->getProposer() === $this) {
+                $areaProposal->setProposer(null);
             }
         }
 

--- a/projects/espace/api/src/Factory/AreaProposalFactory.php
+++ b/projects/espace/api/src/Factory/AreaProposalFactory.php
@@ -28,6 +28,7 @@ final class AreaProposalFactory extends PersistentObjectFactory
             'surfaceToShare' => self::faker()->numberBetween(5, $surfaceTotal),
             'surfaceTotal' => $surfaceTotal,
             'altitude' => self::faker()->numberBetween(0, 1000),
+            'proposer' => PersonFactory::random(),
             'activities' => AreaActivityFactory::randomSet(self::faker()->numberBetween(1, 5)),
         ];
     }


### PR DESCRIPTION
## Summary
- Add a `proposer` (Person) relation on `AreaProposal`, mirroring the existing `requester` relation on `AreaRequest`.
- Auto-link the current authenticated user as proposer on creation via a new `AreaProposalLinkProposerListener` (prePersist), same pattern as `AreaRequestLinkRequesterListener`.
- Expose `proposerFirstName`/`proposerLastName` on the API resource and collection DTO through a new `ProposerTrait`.
- Add migration `Version20260824120000` (`proposer_id` column, FK, index on `area_proposal`).
- Update `AreaProposalFactory` and `AreaProposalFixtures` to generate/depend on a `Person` proposer.

## Test plan
- [x] `php -l` on all new/modified files
- [x] `vendor/bin/phpstan analyse` on the touched files - no errors
- [x] Migration applied cleanly on a local dev DB (`doctrine:migrations:status` -> `Current: Version20260824120000`)
- [x] `doctrine:schema:validate` - mapping OK; only pre-existing cosmetic index-naming drift, nothing introduced by this change