### PR TITLE
feat(api)!: replace the per-API RabbitMQ with one central broker

### DIFF
--- a/.github/workflows/auto-label-pr.yml
+++ b/.github/workflows/auto-label-pr.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write # To create the project labels that do not exist yet
     outputs:
       projects: ${{ steps.gather-projects.outputs.projects }}
     steps:
@@ -37,5 +38,20 @@ jobs:
         if: steps.gather-projects.outputs.projects != ''
         run: |
           labels=$(echo "${{ steps.gather-projects.outputs.projects }}" | sed 's/\[//g' | sed 's/\]//g' | sed 's/"//g')
+
+          # `gh pr edit --add-label` fails atomically on an unknown label, so the
+          # PR that *introduces* an application project used to fail here until
+          # the nightly `Repo | Sync labels` run created its label. Create the
+          # missing ones first, exactly as that workflow does.
+          existing=$(gh label list --limit 200 --json name -q '.[].name')
+          IFS=','
+          for project in $labels; do
+            if ! echo "$existing" | grep -qx "$project"; then
+              echo "Creating label: $project"
+              gh label create "$project" --description "Issues and PRs related to the $project project."
+            fi
+          done
+          unset IFS
+
           gh pr edit ${{ github.event.pull_request.number }} --add-label "$labels"
   

--- a/.moon/tasks/tag-symfony.yml
+++ b/.moon/tasks/tag-symfony.yml
@@ -43,6 +43,7 @@ tasks:
     command: docker compose -p $project up -d
     deps:
       - common-mailpit:up
+      - common-rabbitmq:up
   docker-buildx:
     command: docker buildx build $projectRoot --cache-from ${IMAGE_NAME}:latest --platform linux/arm64,linux/amd64 --target frankenphp_prod -t ${IMAGE_NAME}:latest -t ${IMAGE_NAME}:${GITHUB_SHA} --push
     deps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ make phpunit c="--group e2e"                         # Run by group
   /robust          # Design system project
   /storybook       # Component workshop (Storybook 10)
   /website         # Main Lychen website (SSG)
+  /common          # Shared infra: central RabbitMQ, mailpit, lychen-network
 
 /libs              # Reusable libraries
   /css/core        # Tailwind design tokens
@@ -103,9 +104,11 @@ make phpunit c="--group e2e"                         # Run by group
 ### Backend (Symfony 8.1 + API Platform 4.3 + PHP 8.5)
 - API Platform auto-generates REST APIs from Doctrine entities
 - OpenAPI spec is used to generate the TypeScript SDK at `libs/typescript/tera/api-sdk`
-- State management via Symfony Workflow; messaging via RabbitMQ
+- State management via Symfony Workflow; messaging via RabbitMQ — one **central**
+  broker (`projects/common/rabbitmq`) shared by every API, each on its own vhost
 - FrankenPHP as PHP runtime in Docker; PostgreSQL for storage; Redis for cache
-- Each API project has its own `compose.yml` for local development
+- Each API project has its own `compose.yml` (Postgres + Redis) for local
+  development; RabbitMQ and mailpit are shared via the `lychen-network`
 
 ### Monorepo Wiring
 - Workspace dependencies use `@lychen/<lib-name>` with `workspace:*` protocol

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -30,7 +30,14 @@ A deploy is therefore always a specific, reproducible build — never a moving
 `:latest`.
 
 Projects in the automated pipeline (tagged `dokploy`): `website`, `espace-app`,
-`espace-website`, `tera-api`, `espace-api`, `flora-api`.
+`espace-website`, `tera-api`, `espace-api`, `flora-api`, `common-rabbitmq`.
+
+`common-rabbitmq` is the odd one out: it runs an upstream image rather than one
+we build, so it is absent from **Build & push images** (that matrix selects on the
+`docker-buildx` task) and from the release `image-promote` step (tag `version`).
+It is deployed like the rest — the `IMAGE_TAG` a deploy pins is simply ignored by
+its compose, which pins `RABBITMQ_VERSION` instead. See
+[Central RabbitMQ](#central-rabbitmq) below.
 
 ## Staging (continuous)
 
@@ -128,6 +135,54 @@ Dokploy compose `IMAGES_PREFIX` at the old namespace (`ghcr.io/lychen-lab/`) for
 that one deploy, or rebuild from the target commit on `main` so a new image is
 published under the unified path. Keep the old GHCR packages readable until no
 production deploy references a pre-migration SHA.
+
+## Central RabbitMQ
+
+All three APIs share **one** broker ([`projects/common/rabbitmq`](../projects/common/rabbitmq/)),
+the way they already share `common/mailpit`. Each API gets its **own vhost and
+own credentials**, so the identically-named `async` / `failed` / `sync` queues
+the three Symfony Messenger stacks declare cannot collide, and no API can read
+another's queues.
+
+Users, vhosts and permissions cannot be expressed with `RABBITMQ_DEFAULT_USER`
+and friends (those seed a single vhost, and the node skips them entirely once it
+has definitions to import). They are instead rendered into a definitions file at
+boot by [`entrypoint.sh`](../projects/common/rabbitmq/entrypoint.sh), from these
+variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `RABBITMQ_TENANTS` | `tera espace flora` | Space-separated vhosts to provision. One per API. |
+| `RABBITMQ_<TENANT>_PASSWORD` | the tenant name | Password for that tenant's user, e.g. `RABBITMQ_TERA_PASSWORD`. |
+| `RABBITMQ_ADMIN_USER` / `RABBITMQ_ADMIN_PASSWORD` | `admin` / `admin` | Management-UI account, with access to every vhost. |
+| `RABBITMQ_VERSION` | `4.0.4` | Image tag (`rabbitmq:<version>-management-alpine`). |
+
+The defaults are **local-dev credentials**. Staging and production must override
+every password in the Dokploy compose env. Definitions are re-imported on each
+boot and are idempotent — changing a password there and redeploying updates the
+user in place, leaving queues and messages untouched.
+
+**To deploy it, first (outside this repo):**
+
+1. Create the Compose service in Dokploy from `projects/common/rabbitmq`, and set
+   the passwords above in its env.
+2. Add its compose id as the `COMMON_RABBITMQ_DOKPLOY_ID` secret in the `staging`
+   and `production` GitHub Environments — the deploy workflows derive the secret
+   name from the project id. Without it the deploy job fails.
+3. Attach the API composes to the same Docker network as the broker, and set
+   `MESSENGER_TRANSPORT_DSN` on each of them (see below).
+
+> **Until those three steps are done, deploys of `common-rabbitmq` fail and the
+> APIs have no broker.** Nothing dispatches messages today (no `MessageBusInterface`
+> consumer exists yet) and Messenger connects lazily, so an API still boots and
+> serves traffic without a reachable broker — but the first message dispatched
+> would fail.
+
+> **Runtime config (Dokploy, outside this repo):** each API compose resolves its
+> transport as `${MESSENGER_TRANSPORT_DSN:-amqp://<project>:<project>@rabbitmq:5672/<project>}`.
+> That default is the dev topology (service name `rabbitmq` on `lychen-network`);
+> staging and production must set `MESSENGER_TRANSPORT_DSN` explicitly to the
+> deployed broker's host and the environment's real password.
 
 > **Runtime config (Dokploy, outside this repo):** the API composes resolve their
 > image as `${IMAGES_PREFIX:-}<project>:${IMAGE_TAG:-latest}`. After this change,

--- a/projects/common/rabbitmq/compose.override.yml
+++ b/projects/common/rabbitmq/compose.override.yml
@@ -1,0 +1,19 @@
+# Development environment override
+# Pin the compose project name: `docker compose` would otherwise derive it from
+# this directory (`rabbitmq`), while the Moon tasks pass `-p $project`. Pinning it
+# makes both converge on the same stack.
+name: common-rabbitmq
+services:
+  rabbitmq:
+    ports:
+      # AMQP. The APIs reach the broker over lychen-network; this is for
+      # host-side tooling only.
+      - '${RABBITMQ_AMQP_PORT:-5672}:5672'
+      # Management UI -> http://localhost:15672 (admin / admin)
+      - '${RABBITMQ_MANAGEMENT_PORT:-15672}:15672'
+    networks:
+      - lychen-network
+
+networks:
+  lychen-network:
+    external: true

--- a/projects/common/rabbitmq/compose.yml
+++ b/projects/common/rabbitmq/compose.yml
@@ -1,0 +1,39 @@
+# Central message broker, shared by every API over the `lychen-network`, the same
+# way `common/mailpit` is shared.
+#
+# Each API gets its own vhost *and* its own credentials, so the identically-named
+# `async` / `failed` / `sync` queues that the Symfony Messenger stacks declare
+# cannot collide, and no API can read another's queues. Users, vhosts and
+# permissions are rendered from the environment at boot by `entrypoint.sh` — set
+# `RABBITMQ_<TENANT>_PASSWORD` per environment, and add a domain to
+# `RABBITMQ_TENANTS` to provision it.
+#
+# Dev-only bits (published ports, `lychen-network`) live in compose.override.yml,
+# so this file stays deployable as-is to staging and production via Dokploy.
+services:
+  rabbitmq:
+    # `entrypoint` resets `command` under the Compose spec, so the image's own
+    # default command has to be restated here.
+    command: rabbitmq-server
+    entrypoint: /usr/local/bin/lychen-entrypoint.sh
+    environment:
+      RABBITMQ_ADMIN_PASSWORD: ${RABBITMQ_ADMIN_PASSWORD:-admin}
+      RABBITMQ_ADMIN_USER: ${RABBITMQ_ADMIN_USER:-admin}
+      RABBITMQ_ESPACE_PASSWORD: ${RABBITMQ_ESPACE_PASSWORD:-espace}
+      RABBITMQ_FLORA_PASSWORD: ${RABBITMQ_FLORA_PASSWORD:-flora}
+      RABBITMQ_TENANTS: ${RABBITMQ_TENANTS:-tera espace flora}
+      RABBITMQ_TERA_PASSWORD: ${RABBITMQ_TERA_PASSWORD:-tera}
+    healthcheck:
+      retries: 5
+      start_period: 30s
+      test: [ 'CMD', 'rabbitmq-diagnostics', '-q', 'ping' ]
+      timeout: 10s
+    image: rabbitmq:${RABBITMQ_VERSION:-4.0.4}-management-alpine
+    restart: unless-stopped
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq/
+      - ./entrypoint.sh:/usr/local/bin/lychen-entrypoint.sh:ro
+      - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
+
+volumes:
+  rabbitmq_data:

--- a/projects/common/rabbitmq/entrypoint.sh
+++ b/projects/common/rabbitmq/entrypoint.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# Render the RabbitMQ definitions file from the environment, then hand over to
+# the image's own entrypoint.
+#
+# Why render it instead of committing a definitions.json: a definitions file
+# cannot interpolate environment variables, and RABBITMQ_DEFAULT_USER/PASS/VHOST
+# are no alternative — they only ever seed a *single* vhost, and the node skips
+# them outright as soon as it has definitions to import ("Will not seed default
+# virtual host and user: have definitions to load..."). Rendering at boot is what
+# lets this one compose provision dev, staging and production, each with its own
+# credentials.
+#
+# Definitions are re-imported on every boot and are idempotent: vhosts and users
+# that already exist are updated in place, queues and messages are untouched.
+set -eu
+
+TENANTS="${RABBITMQ_TENANTS:-tera espace flora}"
+ADMIN_USER="${RABBITMQ_ADMIN_USER:-admin}"
+ADMIN_PASSWORD="${RABBITMQ_ADMIN_PASSWORD:-admin}"
+DEFINITIONS_FILE="${RABBITMQ_DEFINITIONS_FILE:-/etc/rabbitmq/definitions.json}"
+
+# JSON-escape a value, so a password containing " or \ cannot break the document.
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+# tenant_password <tenant> — $RABBITMQ_<TENANT>_PASSWORD, falling back to the
+# tenant name so a fresh checkout boots with no configuration at all.
+tenant_password() {
+  _var="RABBITMQ_$(printf '%s' "$1" | tr 'a-z-' 'A-Z_')_PASSWORD"
+  eval "_value=\${$_var:-}"
+  [ -n "$_value" ] || _value="$1"
+  printf '%s' "$_value"
+}
+
+admin="$(json_escape "$ADMIN_USER")"
+users="{\"name\":\"$admin\",\"password\":\"$(json_escape "$ADMIN_PASSWORD")\",\"tags\":[\"administrator\"]}"
+vhosts=""
+permissions=""
+separator=""
+
+for tenant in $TENANTS; do
+  name="$(json_escape "$tenant")"
+  password="$(json_escape "$(tenant_password "$tenant")")"
+
+  users="$users,{\"name\":\"$name\",\"password\":\"$password\",\"tags\":[\"management\"]}"
+  vhosts="$vhosts$separator{\"name\":\"$name\"}"
+  # The tenant owns its vhost; the admin user sees every vhost from the UI.
+  permissions="$permissions$separator{\"user\":\"$name\",\"vhost\":\"$name\",\"configure\":\".*\",\"write\":\".*\",\"read\":\".*\"}"
+  permissions="$permissions,{\"user\":\"$admin\",\"vhost\":\"$name\",\"configure\":\".*\",\"write\":\".*\",\"read\":\".*\"}"
+  separator=","
+done
+
+cat >"$DEFINITIONS_FILE" <<JSON
+{
+  "users": [$users],
+  "vhosts": [$vhosts],
+  "permissions": [$permissions],
+  "topic_permissions": [],
+  "policies": [],
+  "parameters": [],
+  "global_parameters": [],
+  "exchanges": [],
+  "queues": [],
+  "bindings": []
+}
+JSON
+# The rendered file holds plaintext passwords. The server drops privileges to the
+# `rabbitmq` user before reading it, so keep it readable by that user only —
+# root-owned 0600 fails validation with "load_definitions invalid ... cannot be
+# read by the node".
+chmod 0400 "$DEFINITIONS_FILE"
+if [ "$(id -u)" = '0' ] && id rabbitmq >/dev/null 2>&1; then
+  chown rabbitmq:rabbitmq "$DEFINITIONS_FILE"
+fi
+
+echo "lychen: provisioning vhosts [$TENANTS] (admin user '$ADMIN_USER')"
+
+exec docker-entrypoint.sh "$@"

--- a/projects/common/rabbitmq/moon.yml
+++ b/projects/common/rabbitmq/moon.yml
@@ -1,0 +1,9 @@
+id: common-rabbitmq
+language: bash
+# `application` (rather than mailpit's `automation`) so the deploy workflows,
+# which filter on `--layer application --tags dokploy`, pick the broker up.
+layer: application
+stack: backend
+tags:
+  - compose
+  - dokploy

--- a/projects/common/rabbitmq/rabbitmq.conf
+++ b/projects/common/rabbitmq/rabbitmq.conf
@@ -1,0 +1,5 @@
+# Declare users, vhosts and permissions from a definitions file instead of the
+# RABBITMQ_DEFAULT_USER/PASS/VHOST variables: those only ever seed a *single*
+# vhost, and the node skips them entirely once it has definitions to import
+# ("Will not seed default virtual host and user: have definitions to load...").
+load_definitions = /etc/rabbitmq/definitions.json

--- a/projects/espace/api/.env.test
+++ b/projects/espace/api/.env.test
@@ -8,4 +8,4 @@ REDIS_URL=redis://espace-redis:6379
 
 DATABASE_URL=postgresql://userlocal:PasswordForLocal!@espace-database:5432/app?serverVersion=16&charset=utf8
 
-MESSENGER_TRANSPORT_DSN=amqp://app:app@espace-rabbitmq:5672/app
+MESSENGER_TRANSPORT_DSN=amqp://espace:espace@rabbitmq:5672/espace

--- a/projects/espace/api/Makefile
+++ b/projects/espace/api/Makefile
@@ -87,7 +87,7 @@ composer: ## Run composer, pass the parameter "c=" to run a given command, examp
 
 load-fixtures: ## Load fixtures for dev environment and ensure that RabbitMQ messages are deleted
 	@$(DOCKER_COMP) exec -it php sh -c "php -d memory_limit=-1 bin/console do:fi:lo --no-interaction"
-	curl -XDELETE -u guest:guest http://rabbitmq:15672/api/queues/espace/async/contents
+	curl -XDELETE -u espace:espace http://rabbitmq:15672/api/queues/espace/async/contents
 
 phpunit:
 	@$(PHP_CONT) php -d memory_limit=-1 ./vendor/bin/phpunit ${FOLDER}

--- a/projects/espace/api/compose.override.yml
+++ b/projects/espace/api/compose.override.yml
@@ -36,3 +36,14 @@ services:
             - protocol: udp
               published: ${HTTP3_PORT:-29443}
               target: 443
+        networks:
+            # `default` is kept explicitly: naming any network opts a service out
+            # of the implicit one, which would cut the API off from its own
+            # database and redis. Only `api` joins the shared network — database
+            # and redis keep private, non-colliding names on the stack's own.
+            - default
+            - lychen-network
+
+networks:
+    lychen-network:
+        external: true

--- a/projects/espace/api/compose.yml
+++ b/projects/espace/api/compose.yml
@@ -25,14 +25,15 @@ services:
         depends_on:
             database:
                 condition: service_healthy
-            rabbitmq:
-                condition: service_started
             redis:
                 condition: service_started
         environment:
             APP_RUNTIME: Runtime\FrankenPhpSymfony\Runtime
             DATABASE_URL: postgresql://${POSTGRES_USER:-userlocal}:${POSTGRES_PASSWORD:-PasswordForLocal!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-16}&charset=${POSTGRES_CHARSET:-utf8}
-            MESSENGER_TRANSPORT_DSN: amqp://app:app@rabbitmq:5672/app
+            # Central broker (projects/common/rabbitmq), reached over lychen-network in
+            # dev. Staging and production set MESSENGER_TRANSPORT_DSN on the Dokploy
+            # compose so it points at the deployed broker.
+            MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN:-amqp://espace:espace@rabbitmq:5672/espace}
             REDIS_URL: redis://redis:6379
             SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
             TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
@@ -54,23 +55,8 @@ services:
         volumes:
             - redis_data:/data
 
-    rabbitmq:
-        environment:
-            - RABBITMQ_DEFAULT_USER=app
-            - RABBITMQ_DEFAULT_PASS=app
-            - RABBITMQ_DEFAULT_VHOST=app
-        healthcheck:
-            retries: 5
-            start_period: 30s
-            test: [ 'CMD', 'rabbitmq-diagnostics', '-q', 'ping' ]
-            timeout: 10s
-        image: rabbitmq:4.0.4-management-alpine
-        volumes:
-            - rabbitmq_data:/var/lib/rabbitmq/
-
 volumes:
     caddy_config:
     caddy_data:
     database_data:
-    rabbitmq_data:
     redis_data:

--- a/projects/flora/api/.env.test
+++ b/projects/flora/api/.env.test
@@ -8,7 +8,7 @@ REDIS_URL=redis://flora-redis:6379
 
 DATABASE_URL=postgresql://userlocal:PasswordForLocal!@flora-database:5432/app?serverVersion=16&charset=utf8
 
-MESSENGER_TRANSPORT_DSN=amqp://app:app@flora-rabbitmq:5672/app
+MESSENGER_TRANSPORT_DSN=amqp://flora:flora@rabbitmq:5672/flora
 
 JWT_SECRET=Qd5DRtBlOr2LF79DbxfoiGqMWdGDbgmXvlJFJOcLzV1fl0I1LG
 JWT_ALGORITHM=HS256

--- a/projects/flora/api/compose.override.yml
+++ b/projects/flora/api/compose.override.yml
@@ -43,10 +43,6 @@ services:
     networks:
       - lychen-network
 
-  rabbitmq:
-    networks:
-      - lychen-network
-
 networks:
   lychen-network:
     external: true

--- a/projects/flora/api/compose.yml
+++ b/projects/flora/api/compose.yml
@@ -17,14 +17,15 @@ services:
     depends_on:
       database:
         condition: service_healthy
-      rabbitmq:
-        condition: service_started
       redis:
         condition: service_started
     environment:
       APP_RUNTIME: Runtime\FrankenPhpSymfony\Runtime
       DATABASE_URL: postgresql://${POSTGRES_USER:-userlocal}:${POSTGRES_PASSWORD:-PasswordForLocal!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-16}&charset=${POSTGRES_CHARSET:-utf8}
-      MESSENGER_TRANSPORT_DSN: amqp://app:app@rabbitmq:5672/app
+      # Central broker (projects/common/rabbitmq), reached over lychen-network in
+      # dev. Staging and production set MESSENGER_TRANSPORT_DSN on the Dokploy
+      # compose so it points at the deployed broker.
+      MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN:-amqp://flora:flora@rabbitmq:5672/flora}
       REDIS_URL: redis://redis:6379
       SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
       TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
@@ -46,23 +47,8 @@ services:
     volumes:
       - redis_data:/data
 
-  rabbitmq:
-    environment:
-      - RABBITMQ_DEFAULT_USER=app
-      - RABBITMQ_DEFAULT_PASS=app
-      - RABBITMQ_DEFAULT_VHOST=app
-    healthcheck:
-      retries: 5
-      start_period: 30s
-      test: [ 'CMD', 'rabbitmq-diagnostics', '-q', 'ping' ]
-      timeout: 10s
-    image: rabbitmq:4.0.4-management-alpine
-    volumes:
-      - rabbitmq_data:/var/lib/rabbitmq/
-
 volumes:
   caddy_config:
   caddy_data:
   database_data:
-  rabbitmq_data:
   redis_data:

--- a/projects/tera/api/.env.test
+++ b/projects/tera/api/.env.test
@@ -8,7 +8,7 @@ REDIS_URL=redis://tera-redis:6379
 
 DATABASE_URL=postgresql://userlocal:PasswordForLocal!@tera-database:5432/app?serverVersion=16&charset=utf8
 
-MESSENGER_TRANSPORT_DSN=amqp://app:app@tera-rabbitmq:5672/app
+MESSENGER_TRANSPORT_DSN=amqp://tera:tera@rabbitmq:5672/tera
 
 JWT_SECRET=Qd5DRtBlOr2LF79DbxfoiGqMWdGDbgmXvlJFJOcLzV1fl0I1LG
 JWT_ALGORITHM=HS256

--- a/projects/tera/api/Makefile
+++ b/projects/tera/api/Makefile
@@ -87,7 +87,7 @@ composer: ## Run composer, pass the parameter "c=" to run a given command, examp
 
 load-fixtures: ## Load fixtures for dev environment and ensure that RabbitMQ messages are deleted
 	@$(DOCKER_COMP) exec -it php sh -c "php -d memory_limit=-1 bin/console do:fi:lo --no-interaction"
-	curl -XDELETE -u guest:guest http://rabbitmq:15672/api/queues/tera/async/contents
+	curl -XDELETE -u tera:tera http://rabbitmq:15672/api/queues/tera/async/contents
 
 phpunit:
 	@$(PHP_CONT) php -d memory_limit=-1 ./vendor/bin/phpunit ${FOLDER}

--- a/projects/tera/api/compose.override.yml
+++ b/projects/tera/api/compose.override.yml
@@ -43,10 +43,6 @@ services:
     networks:
       - lychen-network
 
-  rabbitmq:
-    networks:
-      - lychen-network
-
 networks:
   lychen-network:
     external: true

--- a/projects/tera/api/compose.yml
+++ b/projects/tera/api/compose.yml
@@ -17,14 +17,15 @@ services:
     depends_on:
       database:
         condition: service_healthy
-      rabbitmq:
-        condition: service_started
       redis:
         condition: service_started
     environment:
       APP_RUNTIME: Runtime\FrankenPhpSymfony\Runtime
       DATABASE_URL: postgresql://${POSTGRES_USER:-userlocal}:${POSTGRES_PASSWORD:-PasswordForLocal!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-16}&charset=${POSTGRES_CHARSET:-utf8}
-      MESSENGER_TRANSPORT_DSN: amqp://app:app@rabbitmq:5672/app
+      # Central broker (projects/common/rabbitmq), reached over lychen-network in
+      # dev. Staging and production set MESSENGER_TRANSPORT_DSN on the Dokploy
+      # compose so it points at the deployed broker.
+      MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN:-amqp://tera:tera@rabbitmq:5672/tera}
       REDIS_URL: redis://redis:6379
       SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
       TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
@@ -46,23 +47,8 @@ services:
     volumes:
       - redis_data:/data
 
-  rabbitmq:
-    environment:
-      - RABBITMQ_DEFAULT_USER=app
-      - RABBITMQ_DEFAULT_PASS=app
-      - RABBITMQ_DEFAULT_VHOST=app
-    healthcheck:
-      retries: 5
-      start_period: 30s
-      test: [ 'CMD', 'rabbitmq-diagnostics', '-q', 'ping' ]
-      timeout: 10s
-    image: rabbitmq:4.0.4-management-alpine
-    volumes:
-      - rabbitmq_data:/var/lib/rabbitmq/
-
 volumes:
   caddy_config:
   caddy_data:
   database_data:
-  rabbitmq_data:
   redis_data:

--- a/templates/php-api/.env.test.twig
+++ b/templates/php-api/.env.test.twig
@@ -8,4 +8,4 @@ REDIS_URL=redis://redis
 
 DATABASE_URL=postgresql://userlocal:PasswordForLocal!@{{ name }}-database:5432/app?serverVersion=16&charset=utf8
 
-MESSENGER_TRANSPORT_DSN=amqp://guest:guest@rabbitmq:5672/{{ name }}-test
+MESSENGER_TRANSPORT_DSN=amqp://{{ name }}:{{ name }}@rabbitmq:5672/{{ name }}

--- a/templates/php-api/Makefile.twig
+++ b/templates/php-api/Makefile.twig
@@ -87,7 +87,7 @@ composer: ## Run composer, pass the parameter "c=" to run a given command, examp
 
 load-fixtures: ## Load fixtures for dev environment and ensure that RabbitMQ messages are deleted
 	@$(DOCKER_COMP) exec -it php sh -c "php -d memory_limit=-1 bin/console do:fi:lo --no-interaction"
-	curl -XDELETE -u guest:guest http://rabbitmq:15672/api/queues/{{ name }}/async/contents
+	curl -XDELETE -u {{ name }}:{{ name }} http://rabbitmq:15672/api/queues/{{ name }}/async/contents
 
 phpunit:
 	@$(PHP_CONT) php -d memory_limit=-1 ./vendor/bin/phpunit ${FOLDER}

--- a/templates/php-api/compose.override.yml.twig
+++ b/templates/php-api/compose.override.yml.twig
@@ -31,3 +31,14 @@ services:
       - protocol: udp
         published: ${HTTP3_PORT:-40443} #TODO Change it
         target: 443
+    networks:
+      # `default` is kept explicitly: naming any network opts a service out of
+      # the implicit one, which would cut the API off from its own database and
+      # redis. Only `api` joins the shared network, where it reaches the central
+      # RabbitMQ and mailpit.
+      - default
+      - lychen-network
+
+networks:
+  lychen-network:
+    external: true

--- a/templates/php-api/compose.yml.twig
+++ b/templates/php-api/compose.yml.twig
@@ -17,14 +17,16 @@ services:
     depends_on:
       database:
         condition: service_healthy
-      rabbitmq:
-        condition: service_started
       redis:
         condition: service_started
     environment:
       APP_RUNTIME: Runtime\FrankenPhpSymfony\Runtime
       DATABASE_URL: postgresql://${POSTGRES_USER:-userlocal}:${POSTGRES_PASSWORD:-PasswordForLocal!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-16}&charset=${POSTGRES_CHARSET:-utf8}
-      MESSENGER_TRANSPORT_DSN: amqp://app:app@rabbitmq:5672/app
+      # Central broker (projects/common/rabbitmq), reached over lychen-network in
+      # dev. Staging and production set MESSENGER_TRANSPORT_DSN on the Dokploy
+      # compose so it points at the deployed broker. Add {{ name }} to
+      # RABBITMQ_TENANTS on the broker so its vhost gets provisioned.
+      MESSENGER_TRANSPORT_DSN: ${MESSENGER_TRANSPORT_DSN:-amqp://{{ name }}:{{ name }}@rabbitmq:5672/{{ name }}}
       REDIS_URL: redis://redis:6379
       SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
       TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
@@ -46,23 +48,8 @@ services:
     volumes:
       - redis_data:/data
 
-  rabbitmq:
-    environment:
-      - RABBITMQ_DEFAULT_USER=app
-      - RABBITMQ_DEFAULT_PASS=app
-      - RABBITMQ_DEFAULT_VHOST=app
-    healthcheck:
-      retries: 5
-      start_period: 30s
-      test: ['CMD', 'rabbitmq-diagnostics', '-q', 'ping']
-      timeout: 10s
-    image: rabbitmq:4.0.4-management-alpine
-    volumes:
-      - rabbitmq_data:/var/lib/rabbitmq/
-
 volumes:
   caddy_config:
   caddy_data:
   database_data:
-  rabbitmq_data:
   redis_data:


### PR DESCRIPTION
## Why

Each API shipped its **own** RabbitMQ, so three brokers ran to serve three Symfony Messenger stacks that never touch each other's queues. This replaces them with a single broker in `projects/common/rabbitmq`, shared over `lychen-network` the same way `common/mailpit` already is.

This deliberately reverses the RabbitMQ part of #160 / #162 — Postgres and Redis stay per-API.

## What changed

**New project [`projects/common/rabbitmq`](https://github.com/lychen-lab/lychen/tree/ai/rabbitmq-central-install-243e5d/projects/common/rabbitmq)** — one broker, with a **vhost _and_ credentials per API** (`tera` / `espace` / `flora`). Per-vhost isolation is not cosmetic: the three stacks each declare `async` / `failed` / `sync`, which would collide on a shared broker, and scoped users mean no API can read another's queues.

Provisioning is **env-driven**, so the one compose serves dev, staging and prod:

| Variable | Default | Purpose |
| --- | --- | --- |
| `RABBITMQ_TENANTS` | `tera espace flora` | vhosts to provision |
| `RABBITMQ_<TENANT>_PASSWORD` | the tenant name | that tenant's password |
| `RABBITMQ_ADMIN_USER` / `_PASSWORD` | `admin` / `admin` | management UI, sees every vhost |
| `RABBITMQ_VERSION` | `4.0.4` | image tag |

**Why an entrypoint renders the definitions file** rather than committing one: `RABBITMQ_DEFAULT_USER/PASS/VHOST` seed only a *single* vhost, and the node skips them outright once it has definitions to import — confirmed in the logs (`Will not seed default virtual host and user: have definitions to load...`). A definitions file cannot interpolate env vars either, so [`entrypoint.sh`](https://github.com/lychen-lab/lychen/blob/ai/rabbitmq-central-install-243e5d/projects/common/rabbitmq/entrypoint.sh) renders it at boot. Re-import on each boot is idempotent: credentials update in place, queues and messages untouched.

**The three APIs** drop their local broker; `MESSENGER_TRANSPORT_DSN` becomes overridable with the dev topology as default. `moon <api>:dev` now starts the central broker alongside mailpit. `templates/php-api` scaffolds new APIs the same way.

## Fixed in passing

- **`espace-api` was on no shared network at all** — it could reach neither mailpit nor the broker. Its `api` now joins `[default, lychen-network]`. Naming any network opts a service out of the implicit `default`, so `default` has to be listed explicitly. Only `api` joins the shared network, so `database`/`redis` keep private, non-colliding names.
- The Makefile `load-fixtures` targets purged the queue as `guest:guest`, which had not existed since the credentials moved to `app`/`app`. They now use the tenant's own credentials — `204` instead of `401`.

## How it was verified

Against a real running broker, not just `docker compose config`:

- **Clean boot from an empty volume:** healthy, 4 users / 3 vhosts / 6 permissions imported, zero boot errors.
- **Real AMQP on 5672** (what Messenger actually uses, not just the HTTP API): each tenant declares the `async` exchange and queue, publishes and consumes on its own vhost. The three `async` queues coexist, isolated.
- **Isolation:** `tera` → `espace` vhost is refused; a wrong password is refused.
- **Staging/prod override path:** passwords containing `"` and `\` render and escape correctly; redeploying onto an existing volume updates credentials in place.
- `moon common-rabbitmq:up` works, and every compose validates on both the dev path and the CI/prod path (`-f compose.yml` alone).

## ⚠️ Required before this reaches staging/prod

The APIs no longer bundle a broker, so one must exist in each environment. Documented in [`docs/deployment.md`](https://github.com/lychen-lab/lychen/blob/ai/rabbitmq-central-install-243e5d/docs/deployment.md):

1. Create the Dokploy Compose from `projects/common/rabbitmq` and set **real passwords** (the defaults are dev credentials).
2. Add its compose id as the `COMMON_RABBITMQ_DOKPLOY_ID` secret to the `staging` and `production` environments — **the deploy job fails without it.**
3. Set `MESSENGER_TRANSPORT_DSN` on each API compose and attach them to the broker's network.

Until then an API still boots and serves traffic — Messenger connects lazily and nothing dispatches today (there is no `MessageBusInterface` consumer yet) — but the first message dispatched would fail.

## Note for reviewers

`common-rabbitmq` is tagged `dokploy` with `layer: application` so the deploy workflows pick it up. It runs an upstream image, so it is correctly absent from **Build & push images** (that matrix selects on the `docker-buildx` task) and from the release `image-promote` step (tag `version`); the `IMAGE_TAG` a deploy pins is simply ignored by its compose, which pins `RABBITMQ_VERSION`.

**Known, pre-existing, not fixed here:** `tera` and `flora` both attach `database` and `redis` to `lychen-network`, so both register those same aliases there and cross-project DNS for them is ambiguous. The `api`-only pattern applied to espace in this PR is the one to converge them on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
